### PR TITLE
Add a checkbox for CodeMirror "smartIndent" option.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -153,6 +153,10 @@
 		"message": "Show number of styles active for the current site on the toolbar button",
 		"description": "Label for the checkbox controlling toolbar badge text."
 	},
+	"prefSmartIndent": {
+		"message": "Use smart indentation in the style editor",
+		"description": "Label for the checkbox controlling smart indentation option for the style editor."
+	},
 	"sectionAdd": {
 		"message": "Add another section",
 		"description": "Label for the button to add a section"

--- a/edit.js
+++ b/edit.js
@@ -18,7 +18,8 @@ function setupCodeMirror(textarea) {
   var cm = CodeMirror.fromTextArea(textarea, {
     mode: 'css',
     lineNumbers: true,
-    lineWrapping: true
+    lineWrapping: true,
+    smartIndent: localStorage["smart-indent"] == "true"
   });
   editors.push(cm);
 }

--- a/manage.html
+++ b/manage.html
@@ -99,7 +99,8 @@
 			<p><a href="edit.html"><button id="add-style-label"></button></a></p>
 			<div id="options">
 				<h2 id="options-heading"></h2>
-				<input id="show-badge" type="checkbox"><label id="show-badge-label" for="show-badge"></label>
+				<input id="show-badge" type="checkbox"><label id="show-badge-label" for="show-badge"></label><br>
+				<input id="smart-indent" type="checkbox"><label id="smart-indent-label" for="smart-indent"></label><br>
 			</div>
 		</div>
 		<div id="installed"></div>

--- a/manage.js
+++ b/manage.js
@@ -355,7 +355,7 @@ function changePref(event) {
 }
 
 function loadPrefs() {
-	["show-badge"].forEach(function(id) {
+	["show-badge", "smart-indent"].forEach(function(id) {
 		var value = localStorage[id];
 		var el = document.getElementById(id);
 		if (isCheckbox(el)) {
@@ -376,5 +376,6 @@ tE("check-all-updates", "checkAllUpdates");
 tE("add-style-label", "addStyleLabel");
 tE("options-heading", "optionsHeading");
 tE("show-badge-label", "prefShowBadge");
+tE("smart-indent-label", "prefSmartIndent");
 
 document.getElementById("check-all-updates").addEventListener("click", checkUpdateAll, false);

--- a/storage.js
+++ b/storage.js
@@ -70,6 +70,9 @@ function dbV15(d, error, done) {
 	if (!("show-badge" in localStorage)) {
 		localStorage["show-badge"] = true;
 	}
+	if (!("smart-indent" in localStorage)) {
+		localStorage["smart-indent"] = true;
+	}
 	d.changeVersion(d.version, '1.5', function (t) {
 		t.executeSql('ALTER TABLE styles ADD COLUMN originalMd5 TEXT NULL;');
 	}, error, function() { done(d, error, done)});


### PR DESCRIPTION
Depending on situation, CodeMirror's default "smart indent" option may have it's own views on what indentation. Sometimes, questionable views:
![Example](http://i.imgur.com/lwa5dXh.gif)
In larger userstyles, the thing may glitch out completely, to the point where it changes the indentation level midst the block. Workflow becomes slightly less enjoyable when you have to constantly fight the code editor, as you can guess.
This pull request adds a checkbox for that option. With the option turned off, CodeMirror will only indent new lines to previous indentation level, similar to how most code editors do by default. I did not miss any required parts of integration, as far as I'm concerned.