### PR TITLE
Only push styles to the top-level document.

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,6 +1,7 @@
 // This happens right away, sometimes so fast that the content script isn't even ready. That's
 // why the content script also asks for this stuff.
 chrome.webNavigation.onCommitted.addListener(function(data) {
+	if (data.frameId !== 0) return;
 	getStyles({matchUrl: data.url, enabled: true, asHash: true}, function(styleHash) {
 		chrome.tabs.sendMessage(data.tabId, {method: "styleApply", styles: styleHash});
 		// Don't show the badge for frames


### PR DESCRIPTION
Push styles only to the main frame of a tab; let the content script pull styles into child frames, as before.

`chrome.tabs.sendMessage` can only broadcast to all frames in a tab until Chrome 41. The main frame always fires `onCommit` before any child frame, so only the main frame hears its own message from `onCommit`. It (and every child frame that's already fired `onCommit`) hears the `onCommit` message for every frame that follows, with the result that the main frame applies all the styles for every frame in the tab.
https://forum.userstyles.org/discussion/45062/stylish-for-chrome-1-3-0b1#Comment_95474