### PR TITLE
Support "breadcrumbs" new style links

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -26,9 +26,6 @@
 				margin-bottom: 0.5em;
 				border-bottom: 1px solid black;
 			}
-			#find-styles, #write-style, #manage-styles {
-				font-size: smaller;
-			}
 			#find-styles, #write-style, #unavailable {
 				margin-bottom: 0.75em;
 			}
@@ -53,9 +50,11 @@
 
 	<div id="installed"></div>
 
-	<div id="find-styles"><a id="find-styles-link" href="#"></a></div>
-	<div id="write-style"><span id="write-style-for"></span></div>
-	<div id="manage-styles"><a id="open-manage-link" href="manage.html"></a></div>
+	<div class="actions">
+		<div id="find-styles"><a id="find-styles-link" href="#"></a></div>
+		<div id="write-style"><span id="write-style-for"></span></div>
+		<div id="manage-styles"><a id="open-manage-link" href="manage.html"></a></div>
+	</div>
 
 	<script src="popup.js"></script>
 

--- a/popup.js
+++ b/popup.js
@@ -19,7 +19,9 @@ chrome.tabs.getSelected(null, function(tab) {
 	document.querySelector("#find-styles a").href = "https://userstyles.org/styles/browse/all/" + encodeURIComponent(tab.url);
 
 	// Write new style links
-	var writeStyleLinks = []
+	var writeStyleLinks = [],
+	    container = document.createElement('span');
+	container.id = "match";
 
 	// For this URL
 	var urlLink = writeStyleTemplate.cloneNode(true);
@@ -38,17 +40,19 @@ chrome.tabs.getSelected(null, function(tab) {
 		var domainLink = writeStyleTemplate.cloneNode(true);
 		domainLink.href = "edit.html?domain=" + encodeURIComponent(domain);
 		domainLink.appendChild(document.createTextNode(domain));
+		domainLink.setAttribute("subdomain", domain.substring(0, domain.indexOf(".")));
 		writeStyleLinks.push(domainLink);
 	});
 
 	var writeStyle = document.querySelector("#write-style");
 	writeStyleLinks.forEach(function(link, index) {
 		if (index > 0) {
-			writeStyle.appendChild(document.createTextNode(" "));
+			container.appendChild(document.createTextNode(" "));
 		}
 		link.addEventListener("click", openLinkInTabOrWindow, false);
-		writeStyle.appendChild(link);
+		container.appendChild(link);
 	});
+	writeStyle.appendChild(container);
 });
 
 function showStyles(styles) {


### PR DESCRIPTION
(1) Adds support for 'new style' links that resemble the page URL. Requires stylesheet support to enable it:
https://userstyles.org/styles/110560/breadcrumbs-new-style-links-stylish-for-chrome

(2) Support moving static menu entries to the top. Wrap the popup actions in a `DIV` so they can be absolutely positioned as a group above the styles.  Requires stylesheet support to enable it:
https://userstyles.org/styles/110565/actions-at-the-top-of-the-menu-stylish-chrome