### PR TITLE
Popup: sort enabled styles first

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -52,7 +52,11 @@ chrome.tabs.getSelected(null, function(tab) {
 });
 
 function showStyles(styles) {
-	styles.sort(function(a, b) { return a.name.localeCompare(b.name)});
+	var enabledFirst = localStorage["popup.enabledFirst"] !== "false";
+	styles.sort(function(a, b) {
+		if (enabledFirst && a.enabled !== b.enabled) return !(a.enabled < b.enabled) ? -1 : 1;
+		return a.name.localeCompare(b.name);
+	});
 	var installed = document.getElementById("installed");
 	if (styles.length == 0) {
 		installed.innerHTML = "<div class='entry' id='no-styles'>" + t('noStylesForSite') + "</div>";


### PR DESCRIPTION
Optionally display enabled styles before disabled styles in the popup menu. Preference `localStorage['popup.enabledFirst']` controls the behavior; default is 'true'.