### PR TITLE
Reload styles on `history.pushState`

### DIFF
--- a/apply.js
+++ b/apply.js
@@ -17,6 +17,10 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
 			for (var styleId in request.styles) {
 				applySections(styleId, request.styles[styleId]);
 			}
+			break;
+		case "styleReplaceAll":
+			replaceAll(request.styles);
+			break;
 	}
 });
 
@@ -53,4 +57,11 @@ function applySections(styleId, sections) {
 		return section.code;
 	}).join("\n")));
 	document.documentElement.appendChild(styleElement);
+}
+
+function replaceAll(newStyles) {
+	Array.prototype.forEach.call(document.querySelectorAll("STYLE.stylish"), function(style) {
+		style.parentNode.removeChild(style);
+	});
+	applyStyles(newStyles);
 }

--- a/background.js
+++ b/background.js
@@ -319,3 +319,20 @@ chrome.tabs.onAttached.addListener(function(tabId, data) {
 		}
 	});
 });
+
+chrome.webNavigation.onHistoryStateUpdated.addListener(function (details) {
+	var now = new Date();
+	console.log("%conHistoryStateUpdate %s: %s(%s)\n url=%s", "color:olive", now.toTimeString().substr(0,8),
+		details.transitionType, details.transitionQualifiers.join(" "), details.url);
+	var request = {
+		enabled: true,
+		matchUrl: details.url,
+		asHash: true
+	};
+	getStyles(request, function(r) {
+		chrome.tabs.sendMessage(details.tabId, {method: "styleReplaceAll", styles: r});
+		if (details.frameId === 0 && localStorage["show-badge"] === "true") {
+			chrome.browserAction.setBadgeText({text: getBadgeText(Object.keys(r)), tabId: details.tabId});
+		}
+	});
+});

--- a/background.js
+++ b/background.js
@@ -1,6 +1,8 @@
 // This happens right away, sometimes so fast that the content script isn't even ready. That's
 // why the content script also asks for this stuff.
-chrome.webNavigation.onCommitted.addListener(function(data) {
+chrome.webNavigation.onCommitted.addListener(webNavigationListener.bind(this, "styleApply"));
+chrome.webNavigation.onHistoryStateUpdated.addListener(webNavigationListener.bind(this, "styleReplaceAll"));
+function webNavigationListener(method, data) {
 	// Until Chrome 41, we can't target a frame with a message
 	// (https://developer.chrome.com/extensions/tabs#method-sendMessage)
 	// so a style affecting a page with an iframe will affect the main page as well.
@@ -9,13 +11,13 @@ chrome.webNavigation.onCommitted.addListener(function(data) {
 		return;
 	}
 	getStyles({matchUrl: data.url, enabled: true, asHash: true}, function(styleHash) {
-		chrome.tabs.sendMessage(data.tabId, {method: "styleApply", styles: styleHash});
+		chrome.tabs.sendMessage(data.tabId, {method: method, styles: styleHash});
 		// Don't show the badge for frames
 		if (data.frameId == 0) {
 			chrome.browserAction.setBadgeText({text: getBadgeText(Object.keys(styleHash)), tabId: data.tabId});
 		}
 	});
-});
+}
 
 chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
 	switch (request.method) {
@@ -316,23 +318,6 @@ chrome.tabs.onAttached.addListener(function(tabId, data) {
 				// If there's only one tab in this window, it's been dragged to new window
 				localStorage['openEditInWindow'] = win.tabs.length == 1 ? "true" : "false";
 			});
-		}
-	});
-});
-
-chrome.webNavigation.onHistoryStateUpdated.addListener(function (details) {
-	var now = new Date();
-	console.log("%conHistoryStateUpdate %s: %s(%s)\n url=%s", "color:olive", now.toTimeString().substr(0,8),
-		details.transitionType, details.transitionQualifiers.join(" "), details.url);
-	var request = {
-		enabled: true,
-		matchUrl: details.url,
-		asHash: true
-	};
-	getStyles(request, function(r) {
-		chrome.tabs.sendMessage(details.tabId, {method: "styleReplaceAll", styles: r});
-		if (details.frameId === 0 && localStorage["show-badge"] === "true") {
-			chrome.browserAction.setBadgeText({text: getBadgeText(Object.keys(r)), tabId: details.tabId});
 		}
 	});
 });


### PR DESCRIPTION
Tumblr's 'new post' buttons rewrite the current URL with `history.pushState`; they can be used with [this style](https://userstyles.org/styles/110723/test-history-pushstate-observer-tumblr) to demonstrate functionality.

Fragment identifier changes can probably be handled similarly with `onReferenceFragmentUpdated`, but I haven't a site to test against.