### PR TITLE
Edit style: add Ctrl-S hotkey to save the style

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -152,7 +152,7 @@
 				<div><label for="enabled" id="enabled-label"></label><input type="checkbox" id="enabled"></div>
 			</section>
 			<button id="to-mozilla"></button><img id="to-mozilla-help" src="help.png"><br><br>
-			<button id="save-button"></button>
+			<button id="save-button" title="Ctrl-S"></button>
 			<a href="manage.html"><button id="cancel-button"></button></a>
 			<div id="options">
 				<h2 id="options-heading"></h2>

--- a/edit.js
+++ b/edit.js
@@ -15,6 +15,7 @@ sectionTemplate.innerHTML = '<label>' + t('sectionCode') + '</label><textarea cl
 var editors = [] // array of all CodeMirror instances
 // replace given textarea with the CodeMirror editor
 function setupCodeMirror(textarea) {
+	CodeMirror.commands.save = function(cm) { save() }
 	var cm = CodeMirror.fromTextArea(textarea, {
 		mode: 'css',
 		lineNumbers: true,


### PR DESCRIPTION
Edit: ~~removed the accelerator hotkeys for other buttons.~~

Adding localized accelerator hotkeys for other buttons would require a lot more work to no benefit, because: 1) those other controls aren't as frequently used as Ctrl-S inside a code textbox while modifying/writing a style, 2) accelerator keys focus the element so it won't be possible to continue typing without tabbing through a lot of controls.