### PR TITLE
Get and set typed preference values

### DIFF
--- a/background.js
+++ b/background.js
@@ -316,7 +316,7 @@ chrome.tabs.onAttached.addListener(function(tabId, data) {
 		if (tabData.url.indexOf(editFullUrl) == 0) {
 			chrome.windows.get(tabData.windowId, {populate: true}, function(win) {
 				// If there's only one tab in this window, it's been dragged to new window
-				localStorage['openEditInWindow'] = win.tabs.length == 1 ? "true" : "false";
+				prefs.setPref('openEditInWindow', win.tabs.length == 1);
 			});
 		}
 	});

--- a/edit.js
+++ b/edit.js
@@ -24,7 +24,7 @@ function setupCodeMirror(textarea) {
 		gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter", "CodeMirror-lint-markers"],
 		matchBrackets: true,
 		lint: CodeMirror.lint.css,
-		smartIndent: (typeof localStorage["smart-indent"] == "undefined") || localStorage["smart-indent"] == "true",
+		smartIndent: prefs.getPref("smart-indent"),
 		extraKeys: {"Ctrl-Space": "autocomplete"}
 	});
 	editors.push(cm);

--- a/messaging.js
+++ b/messaging.js
@@ -10,7 +10,7 @@ function notifyAllTabs(request) {
 }
 
 function updateBadgeText(tab) {
-	if (localStorage["show-badge"] == "true") {
+	if (prefs.getPref("show-badge")) {
 		function stylesReceived(styles) {
 			var t = getBadgeText(styles);
 			console.log("Tab " + tab.id + " (" + tab.url + ") badge text set to '" + t + "'.");

--- a/popup.js
+++ b/popup.js
@@ -122,7 +122,7 @@ function getId(event) {
 
 function openLinkInTabOrWindow(event) {
 	event.preventDefault();
-	if (localStorage['openEditInWindow'] == 'true') {
+	if (prefs.getPref('openEditInWindow', false)) {
 		chrome.windows.create({url: event.target.href});
 	} else {
 		chrome.tabs.create({url: event.target.href});

--- a/storage.js
+++ b/storage.js
@@ -21,17 +21,7 @@ function getDatabase(ready, error) {
 	} else if (stylishDb.version == "1.4") {
 		dbV15(stylishDb, error, ready);
 	} else {
-		defaultPrefs();
 		ready(stylishDb);
-	}
-}
-
-function defaultPrefs() {
-	if (!("show-badge" in localStorage)) {
-		localStorage["show-badge"] = true;
-	}
-	if (!("smart-indent" in localStorage)) {
-		localStorage["smart-indent"] = true;
 	}
 }
 
@@ -148,20 +138,16 @@ function isCheckbox(el) {
 
 function changePref(event) {
 	var el = event.target;
-	var value = isCheckbox(el) ? el.checked : el.value;
-	localStorage[el.id] = value
-	notifyAllTabs({method: "prefChanged", prefName: el.id, value: value});
+	prefs.setPref(el.id, isCheckbox(el) ? el.checked : el.value);
 }
 
 // Accepts a hash of pref name to default value
 function loadPrefs(prefs) {
 	for (var id in prefs) {
-		var value = typeof localStorage[id] == "undefined" ? prefs[id] : localStorage[id];
+		var value = this.prefs.getPref(id);
 		var el = document.getElementById(id);
 		if (isCheckbox(el)) {
-			if (value == "true") {
-				el.checked = true;
-			}
+			el.checked = value;
 		} else {
 			el.value = value;
 		}
@@ -174,7 +160,7 @@ var prefs = {
 
 	// defaults
 	"openEditInWindow": false, // new editor opens in a own browser window
-	"show-badge": false,       // display text on popup menu icon
+	"show-badge": true,        // display text on popup menu icon
 	"smart-indent": true,      // CodeMirror smart indent
 
 	"popup.breadcrumbs": true, // display "New style" links as URL breadcrumbs


### PR DESCRIPTION
Adds a global object `prefs`, with a list of all preferences and their default values, and methods `getPref` and `setPref` to read and write preference values. The objective is to centralize preference handling.

`getPref(key, defaultValue)` returns the user value from `localStorage` if it exists, or the default value from `prefs` if it doesn't. If the optional `defaultValue` is present, it's used instead of the default value in `prefs`. The returned value is converted to the type of the default value.

`setPref(key, value)` sets the user value in `localStorage`. If `value` is `undefined`, the user value is evicted from `localStorage`. The value is converted to a string with `JSON.stringify()` before it's stored.

Some `assert`s which exercise the object: https://gist.github.com/hideheader/2586404ab9fe44f3586f