### PR TITLE
Re-use an active new tab page for manager/editor

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -125,13 +125,20 @@ function openLinkInTabOrWindow(event) {
 	if (localStorage['openEditInWindow'] == 'true') {
 		chrome.windows.create({url: event.target.href});
 	} else {
-		chrome.tabs.create({url: event.target.href});
+		openLink(event);
 	}
 }
 
 function openLink(event) {
 	event.preventDefault();
-	chrome.tabs.create({url: event.target.href});
+	chrome.tabs.query({currentWindow: true, active: true}, function (tabs) {
+		if (tabs && tabs.length && tabs[0].url.match(/^chrome:\/\/newtab\/?$/)) {
+			chrome.tabs.update({url: event.target.href});
+			close(); // close the popup
+		} else {
+			chrome.tabs.create({url: event.target.href});
+		}
+	});
 }
 
 function handleUpdate(style) {


### PR DESCRIPTION
When a new tab page is active both Google Chrome and Firefox re-use it to open settings/preferences, thus it'd be logical for Stylish-Chrome to also do that.

This change actually affects only the "Manage styles" link currently, because the Edit links aren't shown on a new tab page ("Stylish can't style pages like this").