### PR TITLE
Create new styles with `url-prefix()`

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -162,6 +162,8 @@ function init() {
 			section.domains = [params.domain];
 		} else if (params.url) {
 			section.urls = [params.url];
+		} else if (params["url-prefix"]) {
+			section.urlPrefixes = [params["url-prefix"]];
 		}
 		addSection(section);
 		// default to enabled

--- a/popup.js
+++ b/popup.js
@@ -25,13 +25,13 @@ chrome.tabs.getSelected(null, function(tab) {
 
 	// For this URL
 	var urlLink = writeStyleTemplate.cloneNode(true);
-	urlLink.href = "edit.html?url=" + encodeURIComponent(tab.url);
+	urlLink.href = "edit.html?url-prefix=" + encodeURIComponent(tab.url);
 	urlLink.appendChild(document.createTextNode( // switchable; default="this&nbsp;URL"
 		localStorage["popup.breadcrumbs.usePath"] !== "true"
 		? t("writeStyleForURL").replace(/ /g, "\u00a0")
 		: /\/\/[^/]+\/(.*)/.exec(tab.url)[1]
 	));
-	urlLink.title = "url(\"$\")".replace("$", tab.url);
+	urlLink.title = "url-prefix(\"$\")".replace("$", tab.url);
 	writeStyleLinks.push(urlLink);
 	document.querySelector("#write-style").appendChild(urlLink)
 	if (localStorage["popup.breadcrumbs"] !== "false") { // switchable; default=enabled


### PR DESCRIPTION
Use `url-prefix()` instead of `url()` when creating a new style with "this URL". *in re* #42.

`url-prefix()` is used much more often than `url()` [https://github.com/JasonBarnabe/stylish-chrome/issues/42#issuecomment-76667390]. This change eliminates the step of changing the match type in almost all new styles.