### PR TITLE
Edit style: use 'sublime' keymap, add custom keys

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -92,6 +92,10 @@
 		"message": "Disable",
 		"description": "Label for the button to disable a style"
 	},
+	"editGotoLine": {
+		"message": "Goto line (or line:col)",
+		"description": "Go to line or line:column on Ctrl-G in style code editor"
+	},
 	"editStyleHeading": {
 		"message": "Edit Style",
 		"description": "Title of the page for editing styles"

--- a/edit.html
+++ b/edit.html
@@ -29,6 +29,8 @@
 		<script src="codemirror/addon/hint/show-hint.js"></script>
 		<script src="codemirror/addon/hint/css-hint.js"></script>
 
+		<script src="codemirror/keymap/sublime.js"></script>
+
 		<style type="text/css">
 
 			body {

--- a/edit.js
+++ b/edit.js
@@ -25,7 +25,25 @@ function setupCodeMirror(textarea) {
 		matchBrackets: true,
 		lint: CodeMirror.lint.css,
 		smartIndent: prefs.getPref("smart-indent"),
+		keyMap: "sublime",
 		extraKeys: {"Ctrl-Space": "autocomplete"}
+	});
+	cm.addKeyMap({
+		"Ctrl-G": function(cm) {
+			var cur = cm.getCursor();
+			cm.openDialog(t('editGotoLine') + ': <input type="text" style="width: 5em"/>', function(str) {
+				var m = str.match(/^\s*(\d+)(?:\s*:\s*(\d+))?\s*$/);
+				if (m) {
+					cm.setCursor(m[1] - 1, m[2] ? m[2] - 1 : cur.ch);
+				}
+			}, {value: cur.line+1});
+		},
+		"Alt-PageDown": function(cm) {
+			editors[(editors.indexOf(cm) + 1) % editors.length].focus();
+		},
+		"Alt-PageUp": function(cm) {
+			editors[(editors.indexOf(cm) - 1 + editors.length) % editors.length].focus();
+		}
 	});
 	cm.lastChange = cm.changeGeneration();
 	cm.on("change", indicateCodeChange);


### PR DESCRIPTION
Closes #56.

In addition to the default hotkeys like Ctrl-F, Ctrl-G and so on, the 'sublime' keymap adds Windows-standard F3, Shift-F3, Ctrl-H - find, find previous, replace and many more. Since Sublime editor is very popular for code development, we may use this keymap by default for Stylish-Chrome.

Custom hotkeys (my implementation):

| custom key | function |
|---------|-------------|
| Ctrl-G | go to line dialog |
| Alt-PgDn | next code section |
| Alt-PgUp | previous code section |

So Ctrl-G overrides _find next_. Will Mac users of Stylish Chrome complain, I wonder? I mean, all 3 of them!

| sublime key | function |
|---------|-------------|
| Alt-F2 | selectBookmarks |
| Alt-F3 | findAllUnder |
| Alt-Left | goSubwordLeft |
| Alt-Q | wrapLines |
| Alt-Right | goSubwordRight |
| Ctrl-/ | toggleComment |
| Ctrl-D | selectNextOccurrence |
| Ctrl-Down | scrollLineDown |
| Ctrl-Enter | insertLineAfter |
| Ctrl-F2 | toggleBookmark |
| Ctrl-F3 | findUnder |
| Ctrl-F9 | sortLinesInsensitive |
| Ctrl-H | replace |
| Ctrl-I | findIncremental |
| Ctrl-J | joinLines |
| Ctrl-K Ctrl-0 | unfoldAll |
| Ctrl-K Ctrl-A | selectToSublimeMark |
| Ctrl-K Ctrl-Backspace | delLineLeft |
| Ctrl-K Ctrl-C | showInCenter |
| Ctrl-K Ctrl-G | clearBookmarks |
| Ctrl-K Ctrl-K | delLineRight |
| Ctrl-K Ctrl-L | downcaseAtCursor |
| Ctrl-K Ctrl-Space | setSublimeMark |
| Ctrl-K Ctrl-U | upcaseAtCursor |
| Ctrl-K Ctrl-W | deleteToSublimeMark |
| Ctrl-K Ctrl-X | swapWithSublimeMark |
| Ctrl-K Ctrl-Y | sublimeYank |
| Ctrl-K Ctrl-j | unfoldAll |
| Ctrl-L | selectLine |
| Ctrl-M | goToBracket |
| Ctrl-T | transposeChars |
| Ctrl-Up | scrollLineUp |
| Esc | singleSelectionTop |
| F2 | nextBookmark |
| F3 | findNext |
| F9 | sortLines |
| Shift-Alt-Down | selectLinesDownward |
| Shift-Alt-Up | selectLinesUpward |
| Shift-Ctrl-D | duplicateLine |
| Shift-Ctrl-Down | swapLineDown |
| Shift-Ctrl-Enter | insertLineBefore |
| Shift-Ctrl-F2 | clearBookmarks |
| Shift-Ctrl-F3 | findUnderPrevious |
| Shift-Ctrl-I | findIncrementalReverse |
| Shift-Ctrl-K | deleteLine |
| Shift-Ctrl-L | splitSelectionByLine |
| Shift-Ctrl-M | selectBetweenBrackets |
| Shift-Ctrl-Space | selectScope |
| Shift-Ctrl-Up | swapLineUp |
| Shift-Ctrl-[ | fold |
| Shift-Ctrl-] | unfold |
| Shift-F2 | prevBookmark |
| Shift-F3 | findPrev |
| Shift-Tab | indentLess |

Incremental search hotkey does nothing here or I don't know how to use it.