### PR TITLE
Edit style: more tweaks

### DIFF
--- a/codemirror/addon/lint/css-lint.js
+++ b/codemirror/addon/lint/css-lint.js
@@ -18,6 +18,16 @@
 CodeMirror.registerHelper("lint", "css", function(text) {
   var found = [];
   if (!window.CSSLint) return found;
+
+  var rules = CSSLint.getRules();
+  var allowedRules = ["display-property-grouping", "empty-rules", "errors", "known-properties"];
+  CSSLint.clearRules();
+  rules.forEach(function(rule) {
+    if (allowedRules.indexOf(rule.id) >= 0) {
+      CSSLint.addRule(rule);
+    }
+  });
+
   var results = CSSLint.verify(text), messages = results.messages, message = null;
   for ( var i = 0; i < messages.length; i++) {
     message = messages[i];

--- a/edit.html
+++ b/edit.html
@@ -134,10 +134,6 @@
 				display: none;
 			}
 			#sections > div .add-section {
-				display: none;
-			}
-			#sections > div:last-of-type .add-section {
-				display: inline;
 				margin-left: 0.4em;
 			}
 			.applies-to img {

--- a/edit.html
+++ b/edit.html
@@ -143,8 +143,8 @@
 			.applies-to img {
 				vertical-align: bottom;
 			}
-			.CodeMirror-lint-marker-warning {
-				display: none;
+			.CodeMirror-lint-mark-warning {
+				background: none;
 			}
 
 			@media(max-width:737px) {

--- a/edit.js
+++ b/edit.js
@@ -177,7 +177,12 @@ function removeAppliesTo(event) {
 }
 
 function removeSection(event) {
-	event.target.parentNode.parentNode.removeChild(event.target.parentNode);
+    var section = event.target.parentNode;
+    var cm = section.querySelector(".CodeMirror-wrap");
+    if (cm && editors.indexOf(cm.CodeMirror) >= 0) {
+        editors.splice(editors.indexOf(cm.CodeMirror), 1);
+    }
+	section.parentNode.removeChild(section);
 	makeDirty();
 }
 

--- a/edit.js
+++ b/edit.js
@@ -216,10 +216,11 @@ function addSection(event, section) {
 	} else {
 		sections.appendChild(div);
 	}
-	var cm = setupCodeMirror(div.querySelector('.code'));
+	setupCodeMirror(div.querySelector('.code'));
 	if (section) {
 		var index = Array.prototype.indexOf.call(sections.children, section);
-		editors.splice(index, 0, editors.pop());
+        var cm = editors.pop();
+		editors.splice(index, 0, cm);
 		cm.focus();
 	}
 }

--- a/edit.js
+++ b/edit.js
@@ -69,6 +69,12 @@ function makeDirty() {
 }
 
 window.onbeforeunload = function() {
+	prefs.setPref('windowPosition', {
+		left: screenLeft,
+		top: screenTop,
+		width: outerWidth,
+		height: outerHeight
+	});
 	return dirty || isCodeDirty() ? t('styleChangesNotSaved') : null;
 }
 

--- a/edit.js
+++ b/edit.js
@@ -16,7 +16,6 @@ sectionTemplate.innerHTML = '<label>' + t('sectionCode') + '</label><textarea cl
 var editors = [] // array of all CodeMirror instances
 // replace given textarea with the CodeMirror editor
 function setupCodeMirror(textarea) {
-	CodeMirror.commands.save = function(cm) { save() }
 	var cm = CodeMirror.fromTextArea(textarea, {
 		mode: 'css',
 		lineNumbers: true,

--- a/edit.js
+++ b/edit.js
@@ -101,6 +101,13 @@ document.addEventListener("scroll", function(e) {
 	}
 });
 
+document.addEventListener("keydown", function(e) {
+	if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && e.keyCode == 83) {
+		e.preventDefault();
+		save();
+	}
+});
+
 function makeDirty() {
 	dirty = true;
 }

--- a/edit.js
+++ b/edit.js
@@ -171,11 +171,11 @@ function addAppliesTo(list, name, value) {
 	list.appendChild(e);
 }
 
-function addSection(section) {
+function addSection(event, section) {
 	var div = sectionTemplate.cloneNode(true);
 	div.querySelector(".applies-to-help").addEventListener("click", showAppliesToHelp, false);
 	div.querySelector(".remove-section").addEventListener("click", removeSection, false);
-	div.querySelector(".add-section").addEventListener("click", function() {addSection()}, false);
+	div.querySelector(".add-section").addEventListener("click", addSection, false);
 
 	var appliesTo = div.querySelector(".applies-to-list");
 
@@ -211,8 +211,18 @@ function addSection(section) {
 	}
 
 	var sections = document.getElementById("sections");
-	sections.appendChild(div);
-  setupCodeMirror(div.querySelector('.code'));
+	var section = event ? event.target.parentNode : null;
+	if (event && section.nextElementSibling) {
+		sections.insertBefore(div, section.nextElementSibling);
+	} else {
+		sections.appendChild(div);
+	}
+	var cm = setupCodeMirror(div.querySelector('.code'));
+	if (section) {
+		var index = Array.prototype.indexOf.call(sections.children, section);
+		editors.splice(index, 0, editors.pop());
+		cm.focus();
+	}
 }
 
 function removeAppliesTo(event) {
@@ -334,7 +344,7 @@ function init() {
 		} else if (params["url-prefix"]) {
 			section.urlPrefixes = [params["url-prefix"]];
 		}
-		addSection(section);
+		addSection(null, section);
 		// default to enabled
 		document.getElementById("enabled").checked = true
 		document.title = t("addStyleTitle");
@@ -359,7 +369,7 @@ function initWithStyle(style) {
 	Array.prototype.forEach.call(document.querySelectorAll("#sections > div"), function(div) {
 		div.parentNode.removeChild(div);
 	});
-	style.sections.forEach(addSection);
+	style.sections.forEach(function(section) { addSection(null, section) });
 	setupGlobalSearch();
 }
 

--- a/edit.js
+++ b/edit.js
@@ -284,6 +284,7 @@ function init() {
 		document.getElementById("enabled").checked = true
 		document.title = t("addStyleTitle");
 		tE("heading", "addStyleTitle");
+		setupGlobalSearch();
 		return;
 	}
 	// This is an edit

--- a/edit.js
+++ b/edit.js
@@ -154,7 +154,7 @@ function addAppliesTo(list, name, value) {
 		e.querySelector("[name=applies-type]").value = name;
 		e.querySelector("[name=applies-value]").value = value;
 		e.querySelector(".remove-applies-to").addEventListener("click", removeAppliesTo, false);
-		e.querySelector(".applies-value").addEventListener("change", makeDirty, false);
+		e.querySelector(".applies-value").addEventListener("input", makeDirty, false);
 		e.querySelector(".applies-type").addEventListener("change", makeDirty, false);
 	} else if (showingEverything || list.hasChildNodes()) {
 		e = appliesToTemplate.cloneNode(true);
@@ -162,7 +162,7 @@ function addAppliesTo(list, name, value) {
 			e.querySelector("[name=applies-type]").value = list.querySelector("li:last-child [name='applies-type']").value;
 		}
 		e.querySelector(".remove-applies-to").addEventListener("click", removeAppliesTo, false);
-		e.querySelector(".applies-value").addEventListener("change", makeDirty, false);
+		e.querySelector(".applies-value").addEventListener("input", makeDirty, false);
 		e.querySelector(".applies-type").addEventListener("change", makeDirty, false);
 	} else {
 		e = appliesToEverythingTemplate.cloneNode(true);

--- a/popup.js
+++ b/popup.js
@@ -144,7 +144,10 @@ function getId(event) {
 function openLinkInTabOrWindow(event) {
 	event.preventDefault();
 	if (prefs.getPref('openEditInWindow', false)) {
-		chrome.windows.create({url: event.target.href});
+		var options = {url: event.target.href}
+		var wp = prefs.getPref('windowPosition', {});
+		for (var k in wp) options[k] = wp[k];
+		chrome.windows.create(options);
 	} else {
 		openLink(event);
 	}


### PR DESCRIPTION
1. On the _Write a new style_ page also search in all code sections
2. Mostly mute CSSLint, re-enable gutter marks, hide squiggles. Closes #51. Only these are enabled:
  * Parsing Errors
  * Disallow empty rules
  * Require use of known properties
  * Require properties appropriate for display
3. Fix goto next/prev section after deleting one thereof.
4. Remember detached window position and size, closes #47
5. Retain scroll position of window & editor on click, preventing wild jumps of Chrome's scroll-on-focus.
6. Allow adding sections midway, autofocus the manually added one, thus ensuring it's entirely visible
7. Save on Ctrl-S outside code blocks too
8. Warn on losing changes to applies-to text input fields