### PR TITLE
Preferences fixes & improvements

### DIFF
--- a/manage.js
+++ b/manage.js
@@ -15,7 +15,7 @@ function showStyles(styles) {
 	styles.map(createStyleElement).forEach(function(e) {
 		installed.appendChild(e);
 	});
-	loadPrefs({"show-badge": "true"});
+	loadPrefs({"show-badge": true});
 }
 
 function createStyleElement(style) {

--- a/popup.js
+++ b/popup.js
@@ -27,7 +27,7 @@ chrome.tabs.getSelected(null, function(tab) {
 	var urlLink = writeStyleTemplate.cloneNode(true);
 	urlLink.href = "edit.html?url-prefix=" + encodeURIComponent(tab.url);
 	urlLink.appendChild(document.createTextNode( // switchable; default="this&nbsp;URL"
-		prefs.getPref("popup.breadcrumbs.usePath")
+		!prefs.getPref("popup.breadcrumbs.usePath")
 		? t("writeStyleForURL").replace(/ /g, "\u00a0")
 		: /\/\/[^/]+\/(.*)/.exec(tab.url)[1]
 	));

--- a/storage.js
+++ b/storage.js
@@ -151,6 +151,7 @@ function loadPrefs(prefs) {
 		} else {
 			el.value = value;
 		}
+		el.dispatchEvent(new Event("change", {bubbles: true, cancelable: true}));
 		el.addEventListener("change", changePref);
 	}
 }
@@ -191,10 +192,20 @@ var prefs = {
 	},
 	setPref: function(key, value) {
 		if (!(key in this)) console.warn(this.NO_DEFAULT_PREFERENCE, key);
-		if (value === undefined) localStorage.removeItem(key);
-		else localStorage.setItem(key, "string" === typeof value ? value : JSON.stringify(value));
+		var oldValue = this.getPref(key);
 
-		notifyAllTabs({method: "prefChanged", prefName: key, value: value});
+		if (undefined === value || this[key] === value) {
+			localStorage.removeItem(key); // (deleted || default)
+		} else {
+			var strValue = ("string" === typeof value ||
+			               undefined === value) ? value : JSON.stringify(value);
+			localStorage.setItem(key, strValue);
+		}
+
+		var newValue = this.getPref(key);
+		if (newValue !== oldValue) {
+			notifyAllTabs({method: "prefChanged", prefName: key, value: value});
+		}
 	},
 	removePref: function(key) { setPref(key, undefined) }
 };

--- a/storage.js
+++ b/storage.js
@@ -144,7 +144,7 @@ function changePref(event) {
 // Accepts a hash of pref name to default value
 function loadPrefs(prefs) {
 	for (var id in prefs) {
-		var value = this.prefs.getPref(id);
+		var value = this.prefs.getPref(id, prefs[id]);
 		var el = document.getElementById(id);
 		if (isCheckbox(el)) {
 			el.checked = value;
@@ -165,13 +165,7 @@ var prefs = {
 
 	"popup.breadcrumbs": true, // display "New style" links as URL breadcrumbs
 	"popup.breadcrumbs.usePath": false, // use URL path for "this URL"
-
 	"popup.enabledFirst": true,  // display enabled styles before disabled styles
-	"manage.enabledFirst": true, // display enabled styles before disabled styles
-
-	"observer.observeFrameContent": false, // [hh] add MutationObserver inside IFRAMEs
-	"observer.observeFrameLoad": false,    // [hh] add onLoad listener to IFRAMEs
-	// https://github.com/JasonBarnabe/stylish-chrome/pull/39#issuecomment-76681235
 
 	NO_DEFAULT_PREFERENCE: "No default preference for '%s'",
 	UNHANDLED_DATA_TYPE: "Default '%s' is of type '%s' - what should be done with it?",
@@ -198,7 +192,7 @@ var prefs = {
 	setPref: function(key, value) {
 		if (!(key in this)) console.warn(this.NO_DEFAULT_PREFERENCE, key);
 		if (value === undefined) localStorage.removeItem(key);
-		else localStorage.setItem(key, JSON.stringify(value));
+		else localStorage.setItem(key, "string" === typeof value ? value : JSON.stringify(value));
 
 		notifyAllTabs({method: "prefChanged", prefName: key, value: value});
 	},


### PR DESCRIPTION
Fixes: 6ec65ab
1. `loadPrefs` was called with string instead of boolean
2. Sense of boolean `popup.breadcrumbs.usePath` was inverted
3. `loadPrefs` wasn't passing default to `getPrefs`
4. `JSON.stringify(string)` added quotes to string
5. Preferences `manage.enabledFirst`, `observer.observeFrameContent`, `observer.observeFrameLoad` aren't used

Improvements: 0eaa356
1. An element's `change` listener can be used to initialize what it's controlling. `loadPrefs` sends a `change` event to the element after setting the element `value` but before adding its own `change`
listener. Add the element's listener before calling `loadPrefs` to receive the synthetic event.
2. `prefs.setPref` only broadcasts a notification if the value returned by `getPref` changes.
3. A user preference with the same (typed) value as the default is evicted from `localStorage`. (Firefox does this.)