### PR TITLE
Add editor options

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -72,6 +72,26 @@
 		"message": "Checking...",
 		"description": "Text to display when checking a style for an update"
 	},
+	"cm_indentWithTabs": {
+		"message": "Use tabs with smart indentation",
+		"description": "Label for the checkbox controlling tabs with smart indentation option for the style editor."
+	},
+	"cm_keyMap": {
+		"message": "Keymap",
+		"description": "Label for the drop-down list controlling the keymap for the style editor."
+	},
+	"cm_lineWrapping": {
+		"message": "Word wrap",
+		"description": "Label for the checkbox controlling word wrap option for the style editor."
+	},
+	"cm_smartIndent": {
+		"message": "Use smart indentation",
+		"description": "Label for the checkbox controlling smart indentation option for the style editor."
+	},
+	"cm_tabSize": {
+		"message": "Tab size",
+		"description": "Label for the text box controlling tab size option for the style editor."
+	},
 	"dbError": {
 		"message": "An error has occurred using the Stylish database. Would you like to visit a web page with possible solutions?",
 		"description": "Prompt when a DB error is encountered"
@@ -168,10 +188,6 @@
 	"prefShowBadge": {
 		"message": "Show number of styles active for the current site on the toolbar button",
 		"description": "Label for the checkbox controlling toolbar badge text."
-	},
-	"prefSmartIndent": {
-		"message": "Use smart indentation",
-		"description": "Label for the checkbox controlling smart indentation option for the style editor."
 	},
 	"sectionAdd": {
 		"message": "Add another section",

--- a/edit.html
+++ b/edit.html
@@ -173,6 +173,16 @@
 				}
 
 			}
+
+			/* editor options */
+			[type="number"] {
+				max-width: 2.8em;
+				text-align: right;
+			}
+			table, input, select {
+				font-size: inherit;
+			}
+			table td:first-child {min-width: 60px}
 		</style>
 		<script src="storage.js"></script>
 		<script src="messaging.js"></script>
@@ -191,7 +201,34 @@
 			<a href="manage.html"><button id="cancel-button"></button></a>
 			<div id="options">
 				<h2 id="options-heading"></h2>
-				<input id="smart-indent" type="checkbox"><label id="smart-indent-label" for="smart-indent"></label>
+				<table cols="2">
+				<tr>
+					<td colspan="2">
+						<input data-option="lineWrapping" id="editor.lineWrapping" type="checkbox">
+						<label id="lineWrapping-label" for="editor.lineWrapping"></label>
+					</td>
+				</tr>
+				<tr>
+					<td colspan="2">
+						<input data-option="smartIndent" id="editor.smartIndent" type="checkbox">
+						<label id="smartIndent-label" for="editor.smartIndent"></label>
+					</td>
+				</tr>
+				<tr>
+					<td colspan="2">
+						<input data-option="indentWithTabs" id="editor.indentWithTabs" type="checkbox">
+						<label id="indentWithTabs-label" for="editor.indentWithTabs"></label>
+					</td>
+				</tr>
+				<tr>
+					<td><label id="tabSize-label" for="editor.tabSize"></label></td>
+					<td><input data-option="tabSize" id="editor.tabSize" type="number" min="0"></td>
+				</tr>
+				<tr>
+					<td><label id="keyMap-label" for="editor.keyMap"></label></td>
+					<td><select data-option="keyMap" id="editor.keyMap"></select></td>
+				</tr>
+			</table>
 			</div>
 		</div>
 		<section id="sections">

--- a/storage.js
+++ b/storage.js
@@ -162,14 +162,20 @@ var prefs = {
 	// defaults
 	"openEditInWindow": false, // new editor opens in a own browser window
 	"show-badge": true,        // display text on popup menu icon
-	"smart-indent": true,      // CodeMirror smart indent
 
 	"popup.breadcrumbs": true, // display "New style" links as URL breadcrumbs
 	"popup.breadcrumbs.usePath": false, // use URL path for "this URL"
 	"popup.enabledFirst": true,  // display enabled styles before disabled styles
 
 	"manage.onlyEnabled": false, // display only enabled styles
-	"manage.onlyEdited": false,// display only styles created locally
+	"manage.onlyEdited": false,  // display only styles created locally
+	
+	"editor.options": null,    // CodeMirror.defaults.*
+	"editor.lineWrapping": true,   // word wrap
+	"editor.smartIndent": true,    // "smart" indent
+	"editor.indentWithTabs": false,// smart indent with tabs
+	"editor.tabSize": 4,           // tab width, in spaces
+	"editor.keyMap": "sublime",    // keymap
 
 	NO_DEFAULT_PREFERENCE: "No default preference for '%s'",
 	UNHANDLED_DATA_TYPE: "Default '%s' is of type '%s' - what should be done with it?",


### PR DESCRIPTION
1. Add UI controls for `keyMap`, `tabSize`, `indentWithTabs`, and `lineWrapping`; `indentUnit` tracks `tabSize`.
2. Dispatch `change` events from `loadPrefs` to initialize CM options from the controls' event listener.
3. Let the CodeMirror object be arbiter for the editor instances: Move stock options from the `CM.fromTextArea` call into `CM.defaults`. Add a `CM.setOption` method, analogous to the instance method, which updates `CM.defaults` and sets the option in all instances; add a `CM.getOption` which simply returns `CM.defaults[option]`.
4. Move the new editor functions into `CM.commands` and replace the functions with commands.

The changes of #62 are incorporated here.
