### PR TITLE
Remove `eval` from css-lint

### DIFF
--- a/csslint/csslint.js
+++ b/csslint/csslint.js
@@ -4341,9 +4341,12 @@ function PropertyValuePart(text, line, col){
         this.type   = "function";
         this.name   = RegExp.$1;
         this.value  = text;
-    } else if (/^["'][^"']*["']/.test(text)){    //string
+//    } else if (/^["'][^"']*["']/.test(text)){    //string
+//        this.type   = "string";
+//        this.value  = eval(text);
+    } else if (/^(["'])[^\1]*\1/.test(text)){    //string
         this.type   = "string";
-        this.value  = eval(text);
+        this.value  = /^(["'])([^\1]*)\1/.exec(text)[2];
     } else if (Colors[text.toLowerCase()]){  //named color
         this.type   = "color";
         temp        = Colors[text.toLowerCase()].substring(1);

--- a/edit.js
+++ b/edit.js
@@ -329,7 +329,7 @@ window.addEventListener("load", init, false);
 
 function init() {
 	tE("sections-help", "helpAlt", "alt");
-	loadPrefs({"smart-indent": "true"});
+	loadPrefs({"smart-indent": true});
 	var params = getParams();
 	if (!params.id) { // match should be 2 - one for the whole thing, one for the parentheses
 		// This is an add


### PR DESCRIPTION
Evaluate string token with `RegExp.exec()` instead of `eval()`. And, fixing a *second* use of `loadPrefs`.

You need permission for `eval()`; you can't [just ignore it](#51).