### PR TITLE
Manage dirty flags on all inputs

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -199,7 +199,7 @@
 			<button id="to-mozilla"></button><img id="to-mozilla-help" src="help.png"><br><br>
 			<button id="save-button" title="Ctrl-S"></button>
 			<a href="manage.html"><button id="cancel-button"></button></a>
-			<div id="options">
+			<form id="options">
 				<h2 id="options-heading"></h2>
 				<table cols="2">
 				<tr>

--- a/edit.html
+++ b/edit.html
@@ -229,7 +229,7 @@
 					<td><select data-option="keyMap" id="editor.keyMap"></select></td>
 				</tr>
 			</table>
-			</div>
+			</form>
 		</div>
 		<section id="sections">
 			<h2><span id="sections-heading"></span> <img id="sections-help" src="help.png"></h2>

--- a/edit.js
+++ b/edit.js
@@ -46,8 +46,13 @@ function setCleanItem(node, clean) {
 	initTitle();
 }
 function isCleanGlobal() {
-	return Object.keys(items)
-				 .every(function(item) { return items[item] });
+	var clean = Object.keys(items)
+				      .every(function(item) { return items[item] });
+
+	if (clean) document.body.classList.remove("dirty");
+	else document.body.classList.add("dirty");
+
+	return clean;
 }
 function setCleanGlobal(form) {
 	if (!form) form = null;
@@ -66,6 +71,7 @@ function setCleanGlobal(form) {
 
 	editors.forEach(function(cm) {
 		cm.lastChange = cm.changeGeneration();
+		cm.getTextArea().parentNode.defaultValue = cm.lastChange;
 		indicateCodeChange(cm);
 	});
 
@@ -317,8 +323,8 @@ function removeAppliesTo(event) {
 		e.querySelector(".add-applies-to").addEventListener("click", function() {addAppliesTo(this.parentNode.parentNode)}, false);
 		appliesToList.appendChild(e);
 	}
-	Array.prototype.forEach.call(appliesTo.querySelectorAll(".dirty"), function(node) {
-		setCleanItem(node, true);
+	Array.prototype.forEach.call(appliesTo.querySelectorAll("input, select"), function(node) {
+		setCleanItem(node, !node.defaultValue);
 	});
 }
 
@@ -331,9 +337,10 @@ function removeSection(event) {
 		setCleanItem(wrapper.parentNode, true);
     }
 	section.parentNode.removeChild(section);
-	Array.prototype.forEach.call(section.querySelectorAll(".dirty"), function(node) {
-		setCleanItem(node, true);
+	Array.prototype.forEach.call(section.querySelectorAll("input, select"), function(node) {
+		setCleanItem(node, !node.defaultValue);
 	});
+	setCleanItem(section, !section.defaultValue);
 }
 
 function setupGlobalSearch() {


### PR DESCRIPTION
1. Record initial value of text, select, and checkbox elements and re/set a dirty class on each when the value changes.
2. Combine the individual flags into a global dirty flag.
3. Add 'dirty' status to the document title.
