### PR TITLE
Add 'Turn all styles off' to popup

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -108,6 +108,10 @@
 		"message": "Restyle the web with Stylish, a user styles manager. Stylish lets you easily install themes and skins for many popular sites.",
 		"description": "Extension description"
 	},
+	"disableAllStyles": {
+		"message": "Turn all styles off",
+		"description": "Label for the checkbox that turns all enabled styles off."
+	},
 	"disableStyleLabel": {
 		"message": "Disable",
 		"description": "Label for the button to disable a style"

--- a/apply.js
+++ b/apply.js
@@ -14,15 +14,34 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
 			}
 			break;
 		case "styleApply":
-			for (var styleId in request.styles) {
-				applySections(styleId, request.styles[styleId]);
-			}
+			applyStyles(request.styles);
 			break;
 		case "styleReplaceAll":
 			replaceAll(request.styles, document);
 			break;
+		case "styleDisableAll":
+			disableAll(request.disableAll);
+			break;
 	}
 });
+
+var g_disableAll = false;
+function disableAll(disable) {
+	if (!disable === !g_disableAll) return;
+	g_disableAll = disable;
+	disableSheets(g_disableAll, document);
+
+	function disableSheets(disable, doc) {
+		Array.prototype.forEach.call(doc.styleSheets, function(stylesheet) {
+			if (stylesheet.ownerNode.classList.contains("stylish")) {
+				stylesheet.disabled = disable;
+			}
+		});
+		getDynamicIFrames(doc).forEach(function(iframe) {
+			disableSheets(disable, iframe.contentDocument);
+		});
+	}
+}
 
 function removeStyle(id, doc) {
 	var e = doc.getElementById("stylish-" + id);
@@ -35,6 +54,11 @@ function removeStyle(id, doc) {
 }
 
 function applyStyles(styleHash) {
+	if ("disableAll" in styleHash) {
+		disableAll(styleHash.disableAll);
+		delete styleHash.disableAll;
+	}
+
 	for (var styleId in styleHash) {
 		applySections(styleId, styleHash[styleId]);
 	}
@@ -63,7 +87,8 @@ function applySections(styleId, sections) {
 }
 
 function addStyleElement(styleElement, doc) {
-	doc.documentElement.appendChild(doc.importNode(styleElement, true));
+	doc.documentElement.appendChild(doc.importNode(styleElement, true))
+	  .disabled = g_disableAll;
 	getDynamicIFrames(doc).forEach(function(iframe) {
 		addStyleElement(styleElement, iframe.contentDocument);
 	});
@@ -107,9 +132,10 @@ var iframeObserver = new MutationObserver(function(mutations) {
 		Array.prototype.filter.call(mutation.addedNodes, function(node) { return "IFRAME" === node.tagName; }).filter(iframeIsDynamic).forEach(function(iframe) {
 			var doc = iframe.contentDocument;
 			styles.forEach(function(style) {
-				doc.documentElement.appendChild(doc.importNode(style, true));
+				doc.documentElement.appendChild(doc.importNode(style, true))
+				  .disabled = g_disableAll;
 			});
 		});
 	});
 });
-iframeObserver.observe(document, {childList: true, subtree: true});
+iframeObserver.observe(document, {childList: true, subtree: true});

--- a/background.js
+++ b/background.js
@@ -14,6 +14,7 @@ function webNavigationListener(method, data) {
 		chrome.tabs.sendMessage(data.tabId, {method: method, styles: styleHash});
 		// Don't show the badge for frames
 		if (data.frameId == 0 && prefs.getPref("show-badge")) {
+			delete styleHash.disableAll;
 			chrome.browserAction.setBadgeText({text: getBadgeText(Object.keys(styleHash)), tabId: data.tabId});
 		}
 	});
@@ -46,7 +47,7 @@ function getStyles(options, callback) {
 	var asHash = "asHash" in options ? options.asHash : false;
 
 	var callCallback = function() {
-		var styles = asHash ? {} : [];
+		var styles = asHash ? {disableAll: prefs.getPref("disableAll", false)} : [];
 		cachedStyles.forEach(function(style) {
 			if (enabled != null && fixBoolean(style.enabled) != enabled) {
 				return;

--- a/popup.html
+++ b/popup.html
@@ -105,6 +105,12 @@
 				color: inherit;
 				text-decoration: underline;
 			}
+
+			#disableAll {
+				margin: 0 .5ex 0 0;
+				font-size: x-small;
+				vertical-align: text-bottom;
+			}
 		</style>
 
 		<script src="localization.js"></script>
@@ -122,6 +128,7 @@
 	<div class="actions">
 		<div id="find-styles"><a id="find-styles-link" href="#"></a></div>
 		<div id="manage-styles"><a id="open-manage-link" href="manage.html"></a></div>
+		<div><input id="disableAll" type="checkbox"><label id="disableAll-label" for="disableAll"></label></div>
 		<div id="write-style"><span id="write-style-for"></span></div>
 	</div>
 

--- a/popup.js
+++ b/popup.js
@@ -14,6 +14,7 @@ chrome.tabs.getSelected(null, function(tab) {
 	if (!urlWillWork) {
 		document.body.classList.add("blocked");
 		tE("unavailable", "stylishUnavailableForURL");
+		return;
 	}
 
 	chrome.extension.sendMessage({method: "getStyles", matchUrl: tab.url}, showStyles);
@@ -179,7 +180,13 @@ function handleDelete(id) {
 tE("open-manage-link", "openManage");
 tE("write-style-for", "writeStyleFor");
 tE("find-styles-link", "findStylesForSite");
+tE("disableAll-label", "disableAllStyles");
 
 ["find-styles-link", "open-manage-link"].forEach(function(id) {
 	document.getElementById(id).addEventListener("click", openLink, false);
+});
+
+loadPrefs({"disableAll": false})
+document.getElementById("disableAll").addEventListener("change", function(event) {
+	notifyAllTabs({method: "styleDisableAll", disableAll: event.target.checked});
 });

--- a/storage.js
+++ b/storage.js
@@ -162,6 +162,7 @@ var prefs = {
 	// defaults
 	"openEditInWindow": false, // new editor opens in a own browser window
 	"show-badge": true,        // display text on popup menu icon
+	"disableAll": false,       // boss key
 
 	"popup.breadcrumbs": true, // display "New style" links as URL breadcrumbs
 	"popup.breadcrumbs.usePath": false, // use URL path for "this URL"


### PR DESCRIPTION
Uses `CSSStyleSheet.disabled` to disable styles globally while leaving the style elements in place. 
1. Popup sets the value of preference `disableAll` and updates existing content scripts by broadcasting the value in a new message method `styleDisableAll`. 
2. The background script passes the preference value to new content scripts by including it as a property of the `styles` object passed to the `getStyles()` callback.

The new method isn't necessary; the popup could use `styleApply` instead. Closes #74.