### PR TITLE
Edit in Userstyles with the Stylish editor

### DIFF
--- a/install.js
+++ b/install.js
@@ -134,3 +134,34 @@ function getResource(url, callback) {
 		xhr.send();
 	}
 }
+
+
+if (/https?:\/\/userstyles.org\/styles\/\d+\/edit/.test(document.documentURI)
+//  && prefs.getPref("userstyles.useEditor", false)
+  && window.CodeMirror
+  && document.getElementById("css")) {
+	document.documentElement.appendChild(document.createElement("style"))
+	  .textContent =
+".CodeMirror {\n\
+    font-size: 13.333px;\n\
+    border: thin solid #aaa;\n\
+}\n\
+.CodeMirror.focus {\n\
+  outline: -webkit-focus-ring-color auto 5px !important;\n\
+}\n\
+";
+	var cm = CodeMirror.fromTextArea(document.getElementById("css"), {
+		mode: 'css',
+		lineNumbers: true,
+		lineWrapping: true,
+		foldGutter: true,
+		gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
+		smartIndent: true
+	});
+	cm.on("focus", function(cm) {
+		cm.getWrapperElement().classList.add("focus");
+	});
+	cm.on("blur", function(cm) {
+		cm.getWrapperElement().classList.remove("focus");
+	});
+}

--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,13 @@
 			"js": ["apply.js"]
 		},
 		{
+			"matches": ["http://userstyles.org/styles/*", "https://userstyles.org/styles/*"],
+			"run_at": "document_end",
+			"all_frames": false,
+			"css": ["codemirror/lib/codemirror.css"],
+			"js": ["codemirror/lib/codemirror.js", "codemirror/mode/css/css.js"]
+		},
+		{
 			"matches": ["http://userstyles.org/*", "https://userstyles.org/*"],
 			"run_at": "document_end",
 			"all_frames": false,


### PR DESCRIPTION
Add CodeMirror to `textarea.css` in https://userstyles.org/styles/*/edit pages. This is a trial balloon. Before it's pulled the following changes should be considered:
1. The editor functionality should be removed from `edit.js` into its own file for use with both `edit.js` and `install.js`. What you have here is the "old" editor without the recent improvements.
2. Editing in Userstyles with CodeMirror should be optional. It could be associated with a UI control, but really it's there as a circuit breaker to preserve site functionality in case of a CodeMirror catastrophe.
3. If (2), a preference value must be passed to the content script before the editor instance can start.
4. The editor controls are part of `edit.html`. If they're wanted on the Userstyles editor page, they'll need to be copied or abstracted from it.

![userstyles useeditor](https://cloud.githubusercontent.com/assets/10900909/6736280/2fba130a-ce3a-11e4-8205-5f4e848369c4.png)
