### PR TITLE
Add Chrome shortcut keys; update all visible popups on change; add 2 prefs to toolbar button menu

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -181,6 +181,10 @@
 		"message": "Stylish",
 		"description": "Title for the manage page"
 	},
+	"menuShowBadge": {
+		"message": "Show active style count",
+		"description": "Label (must be very short) for the checkbox in the toolbar button context menu controlling toolbar badge text."
+	},
 	"noStylesForSite": {
 		"message": "No styles installed for this site.",
 		"description": "Text displayed when no styles are installed for the current site"

--- a/background.js
+++ b/background.js
@@ -37,6 +37,14 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
 		case "openURL":
 			openURL(request);
 			break;
+		case "styleDisableAll":
+			chrome.contextMenus.update("disableAll", {checked: request.disableAll});
+			break;
+		case "prefChanged":
+			if (request.prefName == "show-badge") {
+				chrome.contextMenus.update("show-badge", {checked: request.value});
+			}
+			break;
 	}
 });
 
@@ -46,13 +54,36 @@ chrome.commands.onCommand.addListener(function(command) {
 			openURL({url: chrome.extension.getURL("manage.html")});
 			break;
 		case "styleDisableAll":
-			var newState = !prefs.getPref("disableAll");
-			prefs.setPref("disableAll", newState);
-			notifyAllTabs({method: "styleDisableAll", disableAll: newState});
-			chrome.extension.sendMessage({method: "updatePopup", reason: "styleDisableAll", disableAll: newState});
+			disableAllStylesToggle();
+			chrome.contextMenus.update("disableAll", {checked: prefs.getPref("disableAll")});
 			break;
 	}
 });
+
+chrome.contextMenus.create({
+	id: "show-badge", title: chrome.i18n.getMessage("menuShowBadge"),
+	type: "checkbox", contexts: ["browser_action"], checked: prefs.getPref("show-badge")
+});
+chrome.contextMenus.create({
+	id: "disableAll", title: chrome.i18n.getMessage("disableAllStyles"),
+	type: "checkbox", contexts: ["browser_action"], checked: prefs.getPref("disableAll")
+});
+chrome.contextMenus.onClicked.addListener(function(info, tab) {
+	if (info.menuItemId == "disableAll") {
+		disableAllStylesToggle(info.checked);
+	} else {
+		prefs.setPref(info.menuItemId, info.checked);
+	}
+});
+
+function disableAllStylesToggle(newState) {
+	if (newState === undefined || newState === null) {
+		newState = !prefs.getPref("disableAll");
+	}
+	prefs.setPref("disableAll", newState);
+	notifyAllTabs({method: "styleDisableAll", disableAll: newState});
+	chrome.extension.sendMessage({method: "updatePopup", reason: "styleDisableAll", disableAll: newState});
+}
 
 function getStyles(options, callback) {
 

--- a/background.js
+++ b/background.js
@@ -40,6 +40,20 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
 	}
 });
 
+chrome.commands.onCommand.addListener(function(command) {
+	switch (command) {
+		case "openManage":
+			openURL({url: chrome.extension.getURL("manage.html")});
+			break;
+		case "styleDisableAll":
+			var newState = !prefs.getPref("disableAll");
+			prefs.setPref("disableAll", newState);
+			notifyAllTabs({method: "styleDisableAll", disableAll: newState});
+			chrome.extension.sendMessage({method: "updatePopup", reason: "styleDisableAll", disableAll: newState});
+			break;
+	}
+});
+
 function getStyles(options, callback) {
 
 	var enabled = fixBoolean(options.enabled);

--- a/edit.js
+++ b/edit.js
@@ -619,6 +619,7 @@ function saveComplete(style) {
 	} else {
 		updateTitle();
 	}
+	chrome.extension.sendMessage({method: "updatePopup", reason: "styleUpdated", style: style});
 }
 
 function showMozillaFormat() {

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,14 @@
 	"background": {
 		"page": "background.html"
 	},
+	"commands": {
+	  "openManage": {
+		"description": "__MSG_openManage__"
+	  },
+	  "styleDisableAll": {
+		"description": "__MSG_disableAllStyles__"
+	  }
+	},
 	"content_scripts": [
 		{
 			"matches": ["http://*/*", "https://*/*", "file:///*"],

--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,7 @@
 	"permissions": [
 		"tabs",
 		"webNavigation",
+		"contextMenus",
 		"http://userstyles.org/",
 		"https://userstyles.org/"
 	],

--- a/storage.js
+++ b/storage.js
@@ -80,7 +80,8 @@ function enableStyle(id, enabled) {
 			chrome.extension.sendMessage({method: "styleChanged"});
 			chrome.extension.sendMessage({method: "getStyles", id: id}, function(styles) {
 				handleUpdate(styles[0]);
-				notifyAllTabs({method:"styleUpdated", style: styles[0]});
+				notifyAllTabs({method: "styleUpdated", style: styles[0]});
+				chrome.extension.sendMessage({method: "updatePopup", reason: "styleUpdated", style: styles[0]});
 			});
 		});
 	});
@@ -94,6 +95,7 @@ function deleteStyle(id) {
 			t.executeSql("DELETE FROM styles WHERE id = ?;", [id]);
 		}, reportError, function() {
 			chrome.extension.sendMessage({method: "styleChanged"});
+			chrome.extension.sendMessage({method: "updatePopup", reason: "styleDeleted", id: id});
 			handleDelete(id);
 			notifyAllTabs({method: "styleDeleted", id: id});
 		});

--- a/storage.js
+++ b/storage.js
@@ -217,7 +217,9 @@ var prefs = {
 
 		var newValue = this.getPref(key);
 		if (newValue !== oldValue) {
-			notifyAllTabs({method: "prefChanged", prefName: key, value: value});
+			var message = {method: "prefChanged", prefName: key, value: value};
+			notifyAllTabs(message);
+			chrome.extension.sendMessage(message);
 		}
 	},
 	removePref: function(key) { setPref(key, undefined) }


### PR DESCRIPTION
* **Hotkeys**
  * hotkey to open Manage styles
  * hotkey to enable/disable all styles

  No default hotkeys are assigned, to customize go to "Keyboard shortcuts" on the Extensions page

* **Toolbar button context menu** features 2 global behavior toggles:
  * show-badge pref, a new i18n label was added as it must be very short to keep the menu small
  * disableAll pref
  
  ![toolbarmenu](https://cloud.githubusercontent.com/assets/1310400/6831645/b97c289c-d332-11e4-9761-c62da79f626f.png)
