### PR TITLE
Editor: option to select CodeMirror CSS theme

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -96,6 +96,10 @@
 		"message": "Tab size",
 		"description": "Label for the text box controlling tab size option for the style editor."
 	},
+	"cm_theme": {
+		"message": "Theme",
+		"description": "Label for the style editor's CSS theme."
+	},
 	"dbError": {
 		"message": "An error has occurred using the Stylish database. Would you like to visit a web page with possible solutions?",
 		"description": "Prompt when a DB error is encountered"

--- a/edit.html
+++ b/edit.html
@@ -322,6 +322,10 @@
 					<label id="keyMap-label" for="editor.keyMap"></label>
 					<select data-option="keyMap" id="editor.keyMap"></select>
 				</div>
+				<div class="option aligned">
+					<label id="theme-label" for="editor.theme"></label>
+					<select data-option="theme" id="editor.theme"></select>
+				</div>
 			</section>
 		</div>
 		<section id="sections">

--- a/storage.js
+++ b/storage.js
@@ -178,6 +178,7 @@ var prefs = {
 	"editor.indentWithTabs": false,// smart indent with tabs
 	"editor.tabSize": 4,           // tab width, in spaces
 	"editor.keyMap": "sublime",    // keymap
+	"editor.theme": "default",     // CSS theme
 
 	NO_DEFAULT_PREFERENCE: "No default preference for '%s'",
 	UNHANDLED_DATA_TYPE: "Default '%s' is of type '%s' - what should be done with it?",


### PR DESCRIPTION
Uses [getPackageDirectoryEntry](https://developer.chrome.com/extensions/runtime#method-getPackageDirectoryEntry) to populate the list of available CSS themes. 

Currently Stylish is shipped with 33 themes in addition to a built-in "default": 3024-day, 3024-night, ambiance, ambiance-mobile, base16-dark, base16-light, blackboard, cobalt, colorforth, eclipse, elegant, erlang-dark, lesser-dark, mbo, mdn-like, midnight, monokai, neat, neo, night, paraiso-dark, paraiso-light, pastel-on-dark, rubyblue, solarized, the-matrix, tomorrow-night-bright, tomorrow-night-eighties, twilight, vibrant-ink, xq-dark, xq-light, zenburn.

A non-elegant timer-based CodeMirror refresh is used because some themes (rubyblue and a few others) have a small issue immediately upon selection: part of the gutter overlaps the text. A straightforward `cm.refresh()` isn't enough, unfortunately.

P.S. While adding the theme option I've simplified acmeEventListener() function a bit, hopefully nobody will mind, otherwise I'll amend the commit.

P.P.S. `Default` (the first list item) isn't translated. I'll do it later when PR #94 is handled. On the other hand we can avoid localizing it by renaming to `[CodeMirror]`.