### PR TITLE
Editor: option to select CodeMirror CSS theme

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -96,9 +96,17 @@
 		"message": "Tab size",
 		"description": "Label for the text box controlling tab size option for the style editor."
 	},
+	"cm_theme": {
+		"message": "Theme",
+		"description": "Label for the style editor's CSS theme."
+	},
 	"dbError": {
 		"message": "An error has occurred using the Stylish database. Would you like to visit a web page with possible solutions?",
 		"description": "Prompt when a DB error is encountered"
+	},
+	"default": {
+		"message": "default",
+		"description": "Default item in various lists"
 	},
 	"deleteStyleLabel": {
 		"message": "Delete",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -104,9 +104,9 @@
 		"message": "An error has occurred using the Stylish database. Would you like to visit a web page with possible solutions?",
 		"description": "Prompt when a DB error is encountered"
 	},
-	"default": {
+	"defaultTheme": {
 		"message": "default",
-		"description": "Default item in various lists"
+		"description": "Default CodeMirror CSS theme option on the edit style page"
 	},
 	"deleteStyleLabel": {
 		"message": "Delete",

--- a/apply.js
+++ b/apply.js
@@ -1,7 +1,14 @@
-var request = {method: "getStyles", matchUrl: location.href, enabled: true, asHash: true};
-if (location.href.indexOf(chrome.extension.getURL("")) == 0) {
-	chrome.extension.getBackgroundPage().getStyles(request, applyStyles);
-} else {
+requestStyles();
+
+function requestStyles() {
+	var request = {method: "getStyles", matchUrl: location.href, enabled: true, asHash: true};
+	if (location.href.indexOf(chrome.extension.getURL("")) == 0) {
+		var bg = chrome.extension.getBackgroundPage();
+		if (bg && bg.getStyles) {
+			bg.getStyles(request, applyStyles);
+			return;
+		}
+	}
 	chrome.extension.sendMessage(request, applyStyles);
 }
 
@@ -63,6 +70,10 @@ function removeStyle(id, doc) {
 }
 
 function applyStyles(styleHash) {
+	if (!styleHash) { // Chrome is starting up
+		requestStyles();
+		return;
+	}
 	if ("disableAll" in styleHash) {
 		disableAll(styleHash.disableAll);
 		delete styleHash.disableAll;

--- a/apply.js
+++ b/apply.js
@@ -1,6 +1,10 @@
 requestStyles();
 
 function requestStyles() {
+	// If this is a Stylish page (Edit Style or Manage Styles),
+	// we'll request the styles directly to minimize delay and flicker,
+	// unless Chrome still starts up and the background page isn't fully loaded.
+	// (Note: in this case the function may be invoked again from applyStyles.)
 	var request = {method: "getStyles", matchUrl: location.href, enabled: true, asHash: true};
 	if (location.href.indexOf(chrome.extension.getURL("")) == 0) {
 		var bg = chrome.extension.getBackgroundPage();

--- a/background.js
+++ b/background.js
@@ -392,3 +392,17 @@ function openURL(options) {
 		}
 	});
 }
+
+var codeMirrorThemes = [chrome.i18n.getMessage("default")];
+chrome.runtime.getPackageDirectoryEntry(function(rootDir) {
+	rootDir.getDirectory("codemirror/theme", {create: false}, function(themeDir) {
+		themeDir.createReader().readEntries(function(entries) {
+			entries
+				.filter(function(entry) { return entry.isFile })
+				.sort(function(a, b) { return a.name < b.name ? -1 : 1 })
+				.forEach(function(entry) {
+					codeMirrorThemes.push(entry.name.replace(/\.css$/, ""));
+				});
+		});
+	});
+});

--- a/background.js
+++ b/background.js
@@ -393,16 +393,7 @@ function openURL(options) {
 	});
 }
 
-var codeMirrorThemes = [chrome.i18n.getMessage("default")];
-chrome.runtime.getPackageDirectoryEntry(function(rootDir) {
-	rootDir.getDirectory("codemirror/theme", {create: false}, function(themeDir) {
-		themeDir.createReader().readEntries(function(entries) {
-			entries
-				.filter(function(entry) { return entry.isFile })
-				.sort(function(a, b) { return a.name < b.name ? -1 : 1 })
-				.forEach(function(entry) {
-					codeMirrorThemes.push(entry.name.replace(/\.css$/, ""));
-				});
-		});
-	});
+var codeMirrorThemes;
+getCodeMirrorThemes(function(themes) {
+	 codeMirrorThemes = themes;
 });

--- a/edit.html
+++ b/edit.html
@@ -276,12 +276,25 @@
 				#sections > *:not(h2) {
 					padding-left: 0.4rem;
 				}
+				.applies-type {
+					width: 30%;
+				}
+			}
+			@media(max-width:500px) {
+				#options {
+					-webkit-column-count: 1;
+				}
+				#options #tabSize-label {
+					position: static;
+				}
 			}
 		</style>
+		<link id="cm-theme" rel="stylesheet">
 		<script src="storage.js"></script>
 		<script src="messaging.js"></script>
 		<script src="localization.js"></script>
 		<script src="apply.js"></script>
+		<script src="edit.js"></script>
 	</head>
 	<body id="stylish-edit">
 		<div id="header">
@@ -322,11 +335,14 @@
 					<label id="keyMap-label" for="editor.keyMap" i18n-text="cm_keyMap"></label>
 					<select data-option="keyMap" id="editor.keyMap"></select>
 				</div>
+				<div class="option aligned">
+					<label id="theme-label" for="editor.theme" i18n-text="cm_theme"></label>
+					<select data-option="theme" id="editor.theme"></select>
+				</div>
 			</section>
 		</div>
 		<section id="sections">
 			<h2><span id="sections-heading" i18n-text="styleSectionsTitle"></span><img id="sections-help" src="help.png" i18n-alt="helpAlt"></h2>
 		</section>
-		<script src="edit.js"></script>
 	</body>
 </html>

--- a/edit.js
+++ b/edit.js
@@ -176,22 +176,22 @@ function initCodeMirror() {
 
 	// initialize global editor controls
 	document.addEventListener("DOMContentLoaded", function() {
-		function concatOption(html, option) {
-			return html + "<option>" + option + "</option>";
+		function optionsHtmlFromArray(options) {
+			return options.map(function(opt) { return "<option>" + opt + "</option>"; }).join("");
 		}
-		var bg = chrome.extension.getBackgroundPage();
 		var themeControl = document.getElementById("editor.theme");
+		var bg = chrome.extension.getBackgroundPage();
 		if (bg && bg.codeMirrorThemes) {
-			themeControl.innerHTML = bg.codeMirrorThemes.reduce(concatOption, "");
+			themeControl.innerHTML = optionsHtmlFromArray(bg.codeMirrorThemes);
 		} else {
 			// Chrome is starting up and shows our edit.html, but the background page isn't loaded yet
-			themeControl.innerHTML = concatOption("", theme == "default" ? t(theme) : theme);
+			themeControl.innerHTML = optionsHtmlFromArray([theme == "default" ? t("defaultTheme") : theme]);
 			getCodeMirrorThemes(function(themes) {
-				themeControl.innerHTML = themes.reduce(concatOption, "");
+				themeControl.innerHTML = optionsHtmlFromArray(themes);
 				themeControl.selectedIndex = Math.max(0, themes.indexOf(theme));
 			});
 		}
-		document.getElementById("editor.keyMap").innerHTML = Object.keys(CM.keyMap).sort().reduce(concatOption, "");
+		document.getElementById("editor.keyMap").innerHTML = optionsHtmlFromArray(Object.keys(CM.keyMap).sort());
 		var controlPrefs = {};
 		document.querySelectorAll("#options *[data-option][id^='editor.']").forEach(function(option) {
 			controlPrefs[option.id] = CM.defaults[option.dataset.option];
@@ -218,7 +218,7 @@ function acmeEventListener(event) {
 		case "theme":
 			var themeLink = document.getElementById("cm-theme");
 			// use non-localized "default" internally
-			if (!value || value == "default" || value == t("default")) {
+			if (!value || value == "default" || value == t("defaultTheme")) {
 				value = "default";
 				if (prefs.getPref(el.id) != value) {
 					prefs.setPref(el.id, value);

--- a/health.js
+++ b/health.js
@@ -1,7 +1,11 @@
-chrome.extension.sendMessage({method: "healthCheck"}, function(ok) {
-	if (!ok) {
-		if (confirm(t("dbError"))) {
+healthCheck();
+
+function healthCheck() {
+	chrome.extension.sendMessage({method: "healthCheck"}, function(ok) {
+		if (ok === undefined) { // Chrome is starting up
+			healthCheck();
+		} else if (!ok && confirm(t("dbError"))) {
 			window.open("http://userstyles.org/dberror");
 		}
-	}
-});
+	});
+}

--- a/manage.js
+++ b/manage.js
@@ -28,6 +28,10 @@ loadPrefs({
 });
 
 function showStyles(styles) {
+	if (!styles) { // Chrome is starting up
+		chrome.extension.sendMessage({method: "getStyles"}, showStyles);
+		return;
+	}
 	styles.sort(function(a, b) { return a.name.localeCompare(b.name)});
 	var installed = document.getElementById("installed");
 	styles.map(createStyleElement).forEach(function(e) {

--- a/storage.js
+++ b/storage.js
@@ -228,7 +228,7 @@ function getCodeMirrorThemes(callback) {
 	chrome.runtime.getPackageDirectoryEntry(function(rootDir) {
 		rootDir.getDirectory("codemirror/theme", {create: false}, function(themeDir) {
 			themeDir.createReader().readEntries(function(entries) {
-				var themes = [chrome.i18n.getMessage("default")];
+				var themes = [chrome.i18n.getMessage("defaultTheme")];
 				entries
 					.filter(function(entry) { return entry.isFile })
 					.sort(function(a, b) { return a.name < b.name ? -1 : 1 })

--- a/storage.js
+++ b/storage.js
@@ -178,6 +178,7 @@ var prefs = {
 	"editor.indentWithTabs": false,// smart indent with tabs
 	"editor.tabSize": 4,           // tab width, in spaces
 	"editor.keyMap": "sublime",    // keymap
+	"editor.theme": "default",     // CSS theme
 
 	NO_DEFAULT_PREFERENCE: "No default preference for '%s'",
 	UNHANDLED_DATA_TYPE: "Default '%s' is of type '%s' - what should be done with it?",

--- a/storage.js
+++ b/storage.js
@@ -223,3 +223,22 @@ var prefs = {
 	},
 	removePref: function(key) { setPref(key, undefined) }
 };
+
+function getCodeMirrorThemes(callback) {
+	chrome.runtime.getPackageDirectoryEntry(function(rootDir) {
+		rootDir.getDirectory("codemirror/theme", {create: false}, function(themeDir) {
+			themeDir.createReader().readEntries(function(entries) {
+				var themes = [chrome.i18n.getMessage("default")];
+				entries
+					.filter(function(entry) { return entry.isFile })
+					.sort(function(a, b) { return a.name < b.name ? -1 : 1 })
+					.forEach(function(entry) {
+						themes.push(entry.name.replace(/\.css$/, ""));
+					});
+				if (callback) {
+					callback(themes);
+				}
+			});
+		});
+	});
+}


### PR DESCRIPTION
Uses [getPackageDirectoryEntry](https://developer.chrome.com/extensions/runtime#method-getPackageDirectoryEntry) to populate the list of available CSS themes.

Currently Stylish is shipped with 34 themes in addition to a built-in "default": 3024-day, 3024-night, ambiance, ambiance-mobile, base16-dark, base16-light, blackboard, cobalt, colorforth, eclipse, elegant, erlang-dark, lesser-dark, liquibyte, mbo, mdn-like, midnight, monokai, neat, neo, night, paraiso-dark, paraiso-light, pastel-on-dark, rubyblue, solarized, the-matrix, tomorrow-night-bright, tomorrow-night-eighties, twilight, vibrant-ink, xq-dark, xq-light, zenburn.

A non-elegant timer-based CodeMirror refresh is used because some themes (rubyblue and a few others) have a small issue immediately upon selection: part of the gutter overlaps the text. A straightforward `cm.refresh()` isn't enough, unfortunately.

~~P.S. `Default` (the first list item) isn't translated. I'll do it later when PR #94 is handled. On the other hand we can avoid localizing it by renaming to `[CodeMirror]`.~~