### PR TITLE
Editor fixes

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -30,6 +30,8 @@
 		<script src="codemirror/addon/hint/css-hint.js"></script>
 
 		<script src="codemirror/keymap/sublime.js"></script>
+		<script src="codemirror/keymap/emacs.js"></script>
+		<script src="codemirror/keymap/vim.js"></script>
 
 		<style type="text/css">
 
@@ -131,7 +133,7 @@
 			.CodeMirror-vscrollbar {
 				margin-bottom: 8px; /* make space for resize-grip */
 			}
-			.CodeMirror-search-field {
+			.CodeMirror-search-field, .CodeMirror-jump-field {
 				-webkit-animation: highlight 3s ease-out;
 			}
 			.CodeMirror-focused {

--- a/edit.html
+++ b/edit.html
@@ -61,10 +61,15 @@
 			.aligned {
 				display: table-row;
 			}
-			.aligned > * {
+			.aligned > *:not(img) {
 				display: table-cell;
 				margin-top: 0.1rem;
 				min-height: 1.4rem;
+			}
+			img[src="help.png"] {
+				cursor: pointer;
+				vertical-align: middle;
+				margin-left: 0.2rem;
 			}
 			input[type="checkbox"] {
 				margin-left: 0.1rem;
@@ -87,11 +92,6 @@
 			#actions > * {
 				margin-right: 0.5rem;
 				margin-bottom: 0.5rem;
-			}
-			#actions img {
-				margin-left: 0.2rem;
-				position: relative;
-				top: 0.2rem;
 			}
 			/* options */
 			#options [type="number"] {
@@ -202,6 +202,55 @@
 			.applies-to img {
 				vertical-align: bottom;
 			}
+			/************ help popup ************/
+			#help-popup {
+				top: 3rem;
+				right: 3rem;
+				max-width: 50vw;
+				position: fixed;
+				display: none;
+				background-color: white;
+				box-shadow: 3px 3px 30px rgba(0, 0, 0, 0.5);
+				padding: 0.5rem;
+				z-index: 9999;
+			}
+			#help-popup .title {
+				font-weight: bold;
+				background-color: rgba(0,0,0,0.05);
+				margin: -0.5rem -0.5rem 0.5rem;
+				padding: 0.5rem;
+			}
+			#help-popup .contents {
+				max-height: calc(100vh - 8rem);
+				overflow-y: auto;
+			}
+			#help-popup .close-icon {
+				cursor: pointer;
+				width: 8px;
+				height: 8px;
+				position: absolute;
+				right: 0.5rem;
+				top: 0.75rem;
+				background: linear-gradient(-45deg, transparent 5px, black 5px, black 6px, transparent 6.5px), linear-gradient(45deg, transparent 5px, black 5px, black 6px, transparent 6.5px);
+			}
+
+			.keymap-list {
+				font-size: 85%;
+				line-height: 1.0;
+				border-spacing: 0;
+				word-break: break-all;
+			}
+			.keymap-list input {
+				width: 100%;
+			}
+			.keymap-list tr:nth-child(odd) {
+				background-color: rgba(0, 0, 0, 0.07);
+			}
+			.keymap-list td:first-child {
+				white-space: nowrap;
+				font-family: monospace;
+				padding-right: 0.5rem;
+			}
 
 			/************ reponsive layouts ************/
 			@media(max-width:737px) {
@@ -248,7 +297,7 @@
 				#options {
 					-webkit-column-count: 2;
 				}
-				#options .aligned > * {
+				#options .aligned > *:not(img) {
 					margin: 1px 0 0 0; /* workaround the flowing-padding column bug in webkit */
 					padding-right: 0.4rem;
 					vertical-align: baseline;
@@ -336,6 +385,7 @@
 				<div class="option aligned">
 					<label id="keyMap-label" for="editor.keyMap" i18n-text="cm_keyMap"></label>
 					<select data-option="keyMap" id="editor.keyMap"></select>
+					<img id="keyMap-help" src="help.png" i18n-alt="helpAlt">
 				</div>
 				<div class="option aligned">
 					<label id="theme-label" for="editor.theme" i18n-text="cm_theme"></label>
@@ -346,5 +396,9 @@
 		<section id="sections">
 			<h2><span id="sections-heading" i18n-text="styleSectionsTitle"></span><img id="sections-help" src="help.png" i18n-alt="helpAlt"></h2>
 		</section>
+		<div id="help-popup">
+			<div class="title"></div><div class="close-icon"></div>
+			<div class="contents"></div>
+		</div>
 	</body>
 </html>

--- a/edit.js
+++ b/edit.js
@@ -426,7 +426,9 @@ function addSection(event, section) {
 		var clickedSection = event.target.parentNode;
 		sections.insertBefore(div, clickedSection.nextElementSibling);
 		var newIndex = document.querySelectorAll("#sections > div").indexOf(clickedSection) + 1;
-		setupCodeMirror(codeElement, newIndex).focus();
+		var cm = setupCodeMirror(codeElement, newIndex);
+		makeSectionVisible(cm);
+		cm.focus()
 	} else {
 		sections.appendChild(div);
 		setupCodeMirror(codeElement);

--- a/edit.js
+++ b/edit.js
@@ -372,6 +372,15 @@ document.addEventListener("keydown", function(event) {
 	}
 });
 
+// Shift-Ctrl-Wheel scrolls entire page even when mouse is over a code editor
+document.addEventListener("wheel", function(event) {
+	if (event.shiftKey && event.ctrlKey && !event.altKey && !event.metaKey) {
+		// Chrome scrolls horizontally when Shift is pressed but on some PCs this might be different
+		window.scrollBy(0, event.deltaX || event.deltaY);
+		event.preventDefault();
+	}
+});
+
 chrome.tabs.query({currentWindow: true}, function(tabs) {
 	isSeparateWindow = tabs.length == 1;
 });
@@ -851,6 +860,7 @@ function showKeyMapHelp() {
 	var keyMap = mergeKeyMaps({}, prefs.getPref("editor.keyMap"), CodeMirror.defaults.extraKeys);
 	var keyMapSorted = Object.keys(keyMap)
 		.map(function(key) { return {key: key, cmd: keyMap[key]} })
+		.concat([{key: "Shift-Ctrl-Wheel", cmd: "scrollWindow"}])
 		.sort(function(a, b) { return a.cmd < b.cmd || (a.cmd == b.cmd && a.key < b.key) ? -1 : 1 });
 	showHelp(t("cm_keyMap") + ": " + prefs.getPref("editor.keyMap"),
 		'<table class="keymap-list">' +

--- a/edit.js
+++ b/edit.js
@@ -548,6 +548,12 @@ function setupGlobalSearch() {
 	}
 
 	function find(activeCM) {
+		editors.lastActive = activeCM;
+		var cm = getEditorInSight();
+		if (cm != activeCM) {
+			cm.focus();
+			activeCM = cm;
+		}
 		var originalOpenDialog = activeCM.openDialog;
 		activeCM.openDialog = function(template, callback, options) {
 			originalOpenDialog.call(activeCM, findTemplate, function(query) {

--- a/edit.js
+++ b/edit.js
@@ -372,6 +372,13 @@ document.addEventListener("keydown", function(event) {
 	}
 });
 
+// remind Chrome to repaint a previously invisible editor box by toggling any element's transform
+// this bug is present in some versions of Chrome (v37-40 or something)
+document.addEventListener("scroll", function(event) {
+	var style = document.getElementById("name").style;
+	style.webkitTransform = style.webkitTransform ? "" : "scale(1)";
+});
+
 // Shift-Ctrl-Wheel scrolls entire page even when mouse is over a code editor
 document.addEventListener("wheel", function(event) {
 	if (event.shiftKey && event.ctrlKey && !event.altKey && !event.metaKey) {


### PR DESCRIPTION
Depends on #108 in `remove scroll-hack and hint-hack, not needed with CM5.2.1` commit.

FIXED:

* fix inconsistent behavior of browser hotkeys (F3, Shift-F3, Ctrl-S/F/G and so on) when they [should] do totally different things in the active keymap.
* fix jumpToLine overriding Ctrl-G in the active keymap, now Ctrl-J is assigned in such cases.
* fix "pcDefault" keymap when running on Windows by adding F3 and Shift-F3 - this keymap should mimick the browser.
* fix non-interceptable Ctrl-(Shift-)N/T/W in all keymaps on Windows.
* fix Alt-PgDn and Alt-PgUp (next/prev section) to work in applies-to inputs.
* fix autocomplete to use correct hotkey depending on active keymap.
* add "vim" keymap.
* add "emacs" keymap.
* workaround for Chrome bug (apparently [this one](https://code.google.com/p/chromium/issues/detail?id=422143)): repaint the page when scrolling.
* use visible code box for 'find' when focused one is offscreen

ADDED:
* `showHelp()` now uses a small html popup with a title and doesn't block the page, can be closed with Esc key or "x" button in the top right corner.
* help button to show assigned hotkeys is added next to the keyMap option
* `Shift-Ctrl`-`Wheel` to scroll the entire page even if the cursor is over a code box, immensely useful in narrow width responsive layout. Couldn't make it work with `Alt-wheel` - the page loses focus and document keyboard listeners don't get events until the page is clicked.
* search in 'applies-to' inputs too

FAILED:

* when the currently focused Applies-to type selector is in dropdown state Chrome doesn't fire any keydown events because it draws the dropdown in a separate toplevel window (at least on WIndows this is typical) outside of the parent window context. We can only circumvent this by implementing our own dropdown selector (it's worth the effort but later).

P.S. thanks to @hideheader's persistence the code seems quite readable and maintainable. And this comes at a very small price: only when editing applies-to fields much more js code is executed on every keypress which I wanted to avoid (at the cost of making the code less readable/maintainable, though), but, unless users will complain, there's no need to worry about speed, with current computers the difference is negligible or even undetectable.

---

~~CM5.2.1 update is 95% of the change so I can split it into a separate PR if needed.~~