### PR TITLE
Editor keymap help: press a hotkey to filter the list

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -161,6 +161,14 @@
 		"message": "Help",
 		"description": "Alternate text for help buttons"
 	},
+	"helpKeyMapHotkey": {
+		"message": "Press a hotkey",
+		"description": "Placeholder text of inputbox in keymap help popup on the edit style page. Must be very short"
+	},
+	"helpKeyMapCommand": {
+		"message": "Type a command name",
+		"description": "Placeholder text of inputbox in keymap help popup on the edit style page. Must be very short"
+	},
 	"installUpdate": {
 		"message": "Install update",
 		"description": "Label for the button to install an update for a single style"

--- a/codemirror/lib/codemirror.js
+++ b/codemirror/lib/codemirror.js
@@ -5720,7 +5720,7 @@
       for (var i = 0; i < keys.length; i++) {
         var val, name;
         if (i == keys.length - 1) {
-          name = keyname;
+          name = keys.join(" ");
           val = value;
         } else {
           name = keys.slice(0, i + 1).join(" ");


### PR DESCRIPTION
* fix CodeMirror.normalizeKeyMap - the bug is [reported](https://github.com/codemirror/CodeMirror/issues/3258) and fixed upstream.
* pressing a hotkey in the first inputbox will filter the list by this hotkey
  * ~~double Esc closes the popup~~
  * ~~double Tab switches to next input~~
  * ~~double Delete and double Backspace clear the input~~
* add localizable placeholders to inputboxes
* set initial focus to the command inputbox

![screenshot-fs8](https://cloud.githubusercontent.com/assets/1310400/7616894/84bd920e-f9b0-11e4-99f3-e0cc3a36abe5.png) ![screenshot2-fs8](https://cloud.githubusercontent.com/assets/1310400/7616907/99c0a60a-f9b0-11e4-960e-7f67e7a8d37b.png)