### PR TITLE
Editor: show a list of all CSSLint messages

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -173,6 +173,14 @@
 		"message": "Install update",
 		"description": "Label for the button to install an update for a single style"
 	},
+	"issues": {
+		"message": "Issues",
+		"description": "Label for the CSSLint issues block on the style edit page"
+	},
+	"issuesHelp": {
+		"message": "The issues found by <a href='https:\/\/github.com\/CSSLint\/csslint' target='_blank'>CSSLint<\/a> with these rules enabled:",
+		"description": "Help popup message for the CSSLint issues block on the style edit page"
+	},
 	"manageFilters": {
 		"message": "Filters",
 		"description": "Label for filters container"

--- a/edit.html
+++ b/edit.html
@@ -131,6 +131,14 @@
 				content: "*";
 				font-weight: bold;
 			}
+			#sections {
+				counter-reset: codebox;
+			}
+			#sections > div > label::after {
+				counter-increment: codebox;
+				content: counter(codebox);
+				margin-left: 0.25rem;
+			}
 			/* code */
 			.code {
 				height: 10rem;
@@ -262,6 +270,50 @@
 				white-space: nowrap;
 				font-family: monospace;
 				padding-right: 0.5rem;
+			}
+
+			/************ lint ************/
+			#lint {
+				display: none;
+			}
+			#lint > div {
+				overflow-y: auto;
+			}
+			#lint table {
+				font-size: 100%;
+				border-spacing: 0;
+				margin-bottom: 1rem;
+				line-height: 1.0;
+			}
+			#lint table:last-child {
+				margin-bottom: 0;
+			}
+			#lint caption {
+				text-align: left;
+				font-weight: bold;
+			}
+			#lint tbody {
+				font-size: 85%;
+				cursor: pointer;
+			}
+			#lint tr:hover {
+				background-color: rgba(0, 0, 0, 0.1);
+			}
+			#lint td[role="severity"] {
+				font-size: 0;
+				width: 16px;
+				padding-right: 0.25rem;
+			}
+			#lint td[role="line"], #lint td[role="sep"] {
+				text-align: right;
+				padding-right: 0;
+			}
+			#lint td[role="col"] {
+				text-align: left;
+				padding-right: 0.25rem;
+			}
+			#lint td[role="message"] {
+				text-align: left;
 			}
 
 			/************ reponsive layouts ************/
@@ -405,6 +457,7 @@
 					<select data-option="theme" id="editor.theme"></select>
 				</div>
 			</section>
+			<section id="lint"><h2 i18n-text="issues"><img id="lint-help" src="help.png" i18n-alt="helpAlt"></h2><div></div></section>
 		</div>
 		<section id="sections">
 			<h2><span id="sections-heading" i18n-text="styleSectionsTitle"></span><img id="sections-help" src="help.png" i18n-alt="helpAlt"></h2>


### PR DESCRIPTION
* An auto-updated list of CSSLint warnings and errors helps a lot in case the errors occur outside of the visible portion of the code (after text replace/paste operation, for example, or in case you simply haven't noticed the icon, which only appears after 0.5s by default, and scrolled the code).
* The entire CSSLint block is hidden when there is nothing to display.
* Click on a message to go to the source.<br>The hovered line is highlighted and uses a hand-shaped cursor, which should suggest it's clickable.

<sup>I heard you like global functions so I added global functions calling global functions while calling global functions.</sup>