### PR TITLE
Manage: remember scroll position, initialize styles earlier

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -409,8 +409,12 @@ chrome.tabs.query({currentWindow: true}, function(tabs) {
 	var windowId = tabs[0].windowId;
 	if (prefs.getPref("openEditInWindow")) {
 		if (tabs.length == 1 && window.history.length == 1) {
-			sessionStorageHash("saveSizeOnClose").set(windowId, true);
-			saveSizeOnClose = true;
+			chrome.windows.getAll(function(windows) {
+				if (windows.length > 1) {
+					sessionStorageHash("saveSizeOnClose").set(windowId, true);
+					saveSizeOnClose = true;
+				}
+			});
 		} else {
 			saveSizeOnClose = sessionStorageHash("saveSizeOnClose").value[windowId];
 		}

--- a/manage.html
+++ b/manage.html
@@ -134,6 +134,7 @@
 		<script src="storage.js"></script>
 		<script src="messaging.js"></script>
 		<script src="apply.js"></script>
+		<script src="manage.js"></script>
 	</head>
 	<body id="stylish-manage">
 		<div id="header">
@@ -158,7 +159,5 @@
 			</div>
 		</div>
 		<div id="installed"></div>
-
-		<script src="manage.js"></script>
 	</body>
 </html>

--- a/manage.js
+++ b/manage.js
@@ -121,10 +121,10 @@ function createStyleElement(style) {
 			var openWindow = left && shift && !ctrl;
 			var openBackgroundTab = (middle && !shift) || (left && ctrl && !shift);
 			var openForegroundTab = (middle && shift) || (left && ctrl && shift);
+			var url = event.target.href || event.target.parentNode.href;
+			event.preventDefault();
+			event.stopPropagation();
 			if (openWindow || openBackgroundTab || openForegroundTab) {
-				event.preventDefault();
-				event.stopPropagation();
-				var url = event.target.href || event.target.parentNode.href;
 				if (openWindow) {
 					var options = prefs.getPref('windowPosition', {});
 					options.url = url;
@@ -138,6 +138,10 @@ function createStyleElement(style) {
 				}
 			} else {
 				history.replaceState({scrollY: window.scrollY}, document.title);
+				getActiveTab(function(tab) {
+					sessionStorageHash("manageStylesHistory").set(tab.id, url);
+					location.href = url;
+				});
 			}
 		}
 	});

--- a/manage.js
+++ b/manage.js
@@ -15,28 +15,32 @@ var styleTemplate = tHTML('\
 ');
 
 var lastUpdatedStyleId = null;
-var installed = document.getElementById("installed");
+var installed;
 
 var appliesToExtraTemplate = document.createElement("span");
 appliesToExtraTemplate.className = "applies-to-extra";
 appliesToExtraTemplate.innerHTML = " " + t('appliesDisplayTruncatedSuffix');
 
 chrome.extension.sendMessage({method: "getStyles"}, showStyles);
-loadPrefs({
-	"manage.onlyEnabled": false,
-	"manage.onlyEdited": false,
-	"show-badge": true
-});
 
 function showStyles(styles) {
 	if (!styles) { // Chrome is starting up
 		chrome.extension.sendMessage({method: "getStyles"}, showStyles);
 		return;
 	}
+	if (!installed) {
+		// "getStyles" message callback is invoked before document is loaded,
+		// postpone the action until DOMContentLoaded is fired
+		document.stylishStyles = styles;
+		return;
+	}
 	styles.sort(function(a, b) { return a.name.localeCompare(b.name)});
 	styles.map(createStyleElement).forEach(function(e) {
 		installed.appendChild(e);
 	});
+	if (history.state) {
+		window.scrollTo(0, history.state.scrollY);
+	}
 }
 
 function createStyleElement(style) {
@@ -132,6 +136,8 @@ function createStyleElement(style) {
 						active: openForegroundTab
 					});
 				}
+			} else {
+				history.replaceState({scrollY: window.scrollY}, document.title);
 			}
 		}
 	});
@@ -468,11 +474,6 @@ function searchStyles(immediately) {
 	}
 }
 
-document.getElementById("check-all-updates").addEventListener("click", checkUpdateAll, false);
-document.getElementById("apply-all-updates").addEventListener("click", applyUpdateAll, false);
-document.getElementById("search").addEventListener("input", searchStyles);
-searchStyles(true); // re-apply filtering on history Back
-
 function onFilterChange (className, event) {
 	installed.classList.toggle(className, event.target.checked);
 }
@@ -480,7 +481,25 @@ function initFilter(className, node) {
 	node.addEventListener("change", onFilterChange.bind(undefined, className), false);
 	onFilterChange(className, {target: node});
 }
-initFilter("enabled-only", document.getElementById("manage.onlyEnabled"));
-initFilter("edited-only", document.getElementById("manage.onlyEdited"));
 
-loadPrefs({"popup.stylesFirst": true});
+document.addEventListener("DOMContentLoaded", function() {
+	installed = document.getElementById("installed");
+	if (document.stylishStyles) {
+		showStyles(document.stylishStyles);
+		delete document.stylishStyles;
+	}
+
+	document.getElementById("check-all-updates").addEventListener("click", checkUpdateAll);
+	document.getElementById("apply-all-updates").addEventListener("click", applyUpdateAll);
+	document.getElementById("search").addEventListener("input", searchStyles);
+	searchStyles(true); // re-apply filtering on history Back
+
+	loadPrefs({
+		"manage.onlyEnabled": false,
+		"manage.onlyEdited": false,
+		"show-badge": true,
+		"popup.stylesFirst": true
+	});
+	initFilter("enabled-only", document.getElementById("manage.onlyEnabled"));
+	initFilter("edited-only", document.getElementById("manage.onlyEdited"));
+});


### PR DESCRIPTION
* initialize styles earlier (ask for styles before BODY is loaded)
* remember scroll position - resolves an extremely annoying issue when going back from an `Edit style` page that was invoked from the `Manage styles` page in case all the installed styles won't fit on one page, the latter being scrolled down.

P.S. `useCapture=false` parameter was deliberately removed from `addEventListener` as it's optional in Chrome [ever since v1.0](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Browser_compatibility) in 2008.