### PR TITLE
Editor: paste from Mozilla format

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -165,6 +165,10 @@
 		"message": "Enable",
 		"description": "Label for the button to enable a style"
 	},
+	"exportLabel": {
+		"message": "Export",
+		"description": "Label for the button to export a style ('edit' page) or all styles ('manage' page)"
+	},
 	"findStylesForSite": {
 		"message": "Find more styles for this site.",
 		"description": "Text for a link that gets a list of styles for the current site"
@@ -180,6 +184,26 @@
 	"helpKeyMapCommand": {
 		"message": "Type a command name",
 		"description": "Placeholder text of inputbox in keymap help popup on the edit style page. Must be very short"
+	},
+	"importLabel": {
+		"message": "Import",
+		"description": "Label for the button to import a style ('edit' page) or all styles ('manage' page)"
+	},
+	"importAppendLabel": {
+		"message": "Append to style",
+		"description": "Label for the button to import a style and append to the existing sections"
+	},
+	"importAppendTooltip": {
+		"message": "Append the imported style to current style",
+		"description": "Tooltip for the button to import a style and append to the existing sections"
+	},
+	"importReplaceLabel": {
+		"message": "Overwrite style",
+		"description": "Label for the button to import and overwrite current style"
+	},
+	"importReplaceTooltip": {
+		"message": "Discard contents of current style and overwrite it with the imported style",
+		"description": "Label for the button to import and overwrite current style"
 	},
 	"installUpdate": {
 		"message": "Install update",
@@ -322,13 +346,21 @@
 		"message": "Sections",
 		"description": "Title for the style sections section"
 	},
-	"styleToMozillaFormat": {
-		"message": "To Mozilla format",
-		"description": "Label for the button that converts the code to Mozilla format"
+	"styleMozillaFormatHeading": {
+		"message": "Mozilla Format",
+		"description": "Heading for the section with buttons to import/export Mozilla format of the style"
+	},
+	"styleFromMozillaFormatPrompt": {
+		"message": "Paste the Mozilla-format code",
+		"description": "Prompt in the dialog displayed after clicking 'Import from Mozilla format' button"
+	},
+	"styleToMozillaFormatTitle": {
+		"message": "Style in Mozilla format",
+		"description": "Title of the popup with the style code in Mozilla format, shown after pressing the Export button on Edit style page"
 	},
 	"styleToMozillaFormatHelp": {
 		"message": "The Mozilla format of the code can be used with Stylish for Firefox and can be submitted to userstyles.org.",
-		"description": "Help info for the button that converts the code to Mozilla format"
+		"description": "Help info for the Mozilla format header section that converts the code to/from Mozilla format"
 	},
 	"styleUpdate": {
 		"message": "Are you sure you want to update '$stylename$'?",

--- a/csslint/csslint.js
+++ b/csslint/csslint.js
@@ -2061,21 +2061,24 @@ Parser.prototype = function(){
                     col:       token.startCol
                 });
 
-                while(true) {
-                    if (tokenStream.peek() == Tokens.PAGE_SYM){
-                        this._page();
-                    } else if (tokenStream.peek() == Tokens.FONT_FACE_SYM){
-                        this._font_face();
-                    } else if (tokenStream.peek() == Tokens.VIEWPORT_SYM){
-                        this._viewport();
-                    } else if (tokenStream.peek() == Tokens.MEDIA_SYM){
-                        this._media();
-                    } else if (!this._ruleset()){
-                        break;
+                var ok = true;
+                while(ok) {
+                    switch (tokenStream.peek()) {
+                        case Tokens.PAGE_SYM:       this._page(); break;
+                        case Tokens.FONT_FACE_SYM:  this._font_face(); break;
+                        case Tokens.VIEWPORT_SYM:   this._viewport(); break;
+                        case Tokens.MEDIA_SYM:      this._media(); break;
+                        case Tokens.KEYFRAMES_SYM:  this._keyframes(); break;
+                        case Tokens.DOCUMENT_SYM:   this._document(); break;
+                        default:
+                            if (!this._ruleset()) {
+                                ok = false;
+                            }
                     }
                 }
 
                 tokenStream.mustMatch(Tokens.RBRACE);
+                token = tokenStream.token();
                 this._readWhitespace();
 
                 this.fire({
@@ -3259,6 +3262,7 @@ Parser.prototype = function(){
 
                 this._readWhitespace();
                 tokenStream.mustMatch(Tokens.RBRACE);
+                this._readWhitespace();
 
             },
 

--- a/edit.html
+++ b/edit.html
@@ -241,7 +241,7 @@
 				background-color: white;
 				box-shadow: 3px 3px 30px rgba(0, 0, 0, 0.5);
 				padding: 0.5rem;
-				z-index: 9999;
+				z-index: 99;
 			}
 			#help-popup .title {
 				font-weight: bold;
@@ -280,6 +280,19 @@
 				white-space: nowrap;
 				font-family: monospace;
 				padding-right: 0.5rem;
+			}
+
+			#help-popup button[name^="import"] {
+				line-height: 1.5rem;
+				padding: 0 0.5rem;
+				margin: 0.5rem 0 0 0.5rem;
+				pointer-events: none;
+				opacity: 0.5;
+				float: right;
+			}
+			#help-popup.ready button[name^="import"] {
+				pointer-events: all;
+				opacity: 1.0;
 			}
 
 			/************ lint ************/
@@ -528,9 +541,16 @@
 				</div>
 			</section>
 			<section id="actions">
-				<div><button id="beautify" i18n-text="styleBeautify"></button> <button id="to-mozilla" i18n-text="styleToMozillaFormat"></button><img id="to-mozilla-help" src="help.png"></div>
-				<div><a href="manage.html"><button id="cancel-button" i18n-text="styleCancelEditLabel"></button></a></div>
-				<div><button id="save-button" title="Ctrl-S" i18n-text="styleSaveLabel"></button></div>
+				<div>
+					<button id="save-button" title="Ctrl-S" i18n-text="styleSaveLabel"></button>
+					<button id="beautify" i18n-text="styleBeautify"></button>
+					<a href="manage.html"><button id="cancel-button" i18n-text="styleCancelEditLabel"></button></a>
+				</div>
+				<div>
+					<h2 id="mozilla-format-heading" i18n-text="styleMozillaFormatHeading"><img id="to-mozilla-help" src="help.png"></h2>
+					<button id="from-mozilla" i18n-text="importLabel"></button>
+					<button id="to-mozilla" i18n-text="exportLabel"></button>
+				</div>
 			</section>
 			<section id="options">
 				<h2 id="options-heading" i18n-text="optionsHeading"></h2>

--- a/storage.js
+++ b/storage.js
@@ -262,14 +262,16 @@ function sessionStorageHash(name) {
 }
 
 function shallowCopy(obj) {
-	if (typeof obj != "object") {
-		return obj;
+	return typeof obj == "object" ? shallowMerge(obj, {}) : obj;
+}
+
+function shallowMerge(from, to) {
+	if (typeof from == "object" && typeof to == "object") {
+		for (var k in from) {
+			to[k] = from[k];
+		}
 	}
-	var copy = {};
-	for (var k in obj) {
-		copy[k] = obj[k];
-	}
-	return copy;
+	return to;
 }
 
 function equal(a, b) {


### PR DESCRIPTION
Closes #31

* CSSLint's [parser-lib](https://github.com/CSSLint/parser-lib) is used, with a few fixes ([PR for @keyframes](https://github.com/CSSLint/parser-lib/pull/157), nested doc handling is pending submission).
* `@-moz-document` and unprefixed `@document` are recognized
* The parser understands nested `@-moz-document` and puts a breaker `/*************/` between the parts of such divided outer sections
* Likewise, a global section is constructed from stuff outside of recognized sections
* If the global section only contains `@namespace url(http://www.w3.org/1999/xhtml);` and comments then it's not created.

A combined approach is used - parsing plus direct extraction of an entire section text in one go and a few regexps for detecting minor stuff. It seems failproof to me, moreover it'll require twice as much code for a pure parser approach, which is not necessarily more readable or failproof.

P.S. Now it seems possible to switch to a single-section layout, I think I'll start working on it lazily and then we'll have it as an option. And then maybe we'll make it the only choice if it proves to be reliable and more convenient (the latter would probably require some kind of visual indication of section's start and end, as well as `<`, `>` buttons and hotkeys to jump between sections).