### PR TITLE
Fixes

### DIFF
--- a/background.js
+++ b/background.js
@@ -76,7 +76,7 @@ chrome.commands.onCommand.addListener(function(command) {
 
 // contextMenus API is present in ancient Chrome but it throws an exception
 // upon encountering the unsupported parameter value "browser_action", so we have to catch it.
-
+try {
 chrome.contextMenus.create({
 	id: "show-badge", title: chrome.i18n.getMessage("menuShowBadge"),
 	type: "checkbox", contexts: ["browser_action"], checked: prefs.getPref("show-badge")
@@ -85,6 +85,7 @@ chrome.contextMenus.create({
 	id: "disableAll", title: chrome.i18n.getMessage("disableAllStyles"),
 	type: "checkbox", contexts: ["browser_action"], checked: prefs.getPref("disableAll")
 }, function() { var clearError = chrome.runtime.lastError; });
+} catch(e) {}
 chrome.contextMenus.onClicked.addListener(function(info, tab) {
 	if (info.menuItemId == "disableAll") {
 		disableAllStylesToggle(info.checked);

--- a/edit.js
+++ b/edit.js
@@ -58,6 +58,9 @@ var jumpToLineTemplate = t('editGotoLine') + ': <input class="CodeMirror-jump-fi
 	NodeList.prototype[method]= Array.prototype[method];
 });
 
+// Chrome pre-34
+Element.prototype.matches = Element.prototype.matches || Element.prototype.webkitMatchesSelector;
+
 // reroute handling to nearest editor when keypress resolves to one of these commands
 var commandsToReroute = {
 	save: true, jumpToLine: true, nextEditor: true, prevEditor: true,

--- a/edit.js
+++ b/edit.js
@@ -952,8 +952,8 @@ function initWithStyle(style) {
 	});
 	var queue = style.sections.length ? style.sections : [{code: ""}];
 	var queueStart = new Date().getTime();
-	// after 200ms the sections will be added asynchronously
-	while (new Date().getTime() - queueStart <= 200 && queue.length) {
+	// after 100ms the sections will be added asynchronously
+	while (new Date().getTime() - queueStart <= 100 && queue.length) {
 		maximizeCodeHeight(addSection(null, queue.shift()), !queue.length);
 	}
 	if (queue.length) {

--- a/localization.js
+++ b/localization.js
@@ -35,13 +35,14 @@ function tNodeList(nodes) {
 		if (node.nodeType != 1) { // not an ELEMENT_NODE
 			continue;
 		}
-		for (var a = 0; a < node.attributes.length; a++) {
-			var name = node.attributes[a].nodeName;
+		for (var a = node.attributes.length - 1; a >= 0; a--) {
+			var attr = node.attributes[a];
+			var name = attr.nodeName;
 			if (name.indexOf("i18n-") != 0) {
 				continue;
 			}
 			name = name.substr(5); // "i18n-".length
-			var value = t(node.attributes[a].nodeValue);
+			var value = t(attr.nodeValue);
 			switch (name) {
 				case "text":
 					node.insertBefore(document.createTextNode(value), node.firstChild);
@@ -52,6 +53,7 @@ function tNodeList(nodes) {
 				default:
 					node.setAttribute(name, value);
 			}
+			node.removeAttributeNode(attr);
 		}
 	}
 }
@@ -69,5 +71,6 @@ function tDocLoader() {
 	observer.observe(document, {subtree: true, childList: true});
 	document.addEventListener("DOMContentLoaded", function() {
 		observer.disconnect();
+		tNodeList(document.querySelectorAll("*"));
 	});
 }

--- a/messaging.js
+++ b/messaging.js
@@ -76,14 +76,9 @@ function getActiveTabRealURL(callback) {
 function getTabRealURL(tab, callback) {
 	if (tab.url != "chrome://newtab/") {
 		callback(tab.url);
-		return;
-	}
-	chrome.webNavigation.getAllFrames({tabId: tab.id}, function(frames) {
-		frames.some(function(frame) {
-			if (frame.parentFrameId == -1) { // parentless frame is the main frame
-				callback(frame.url);
-				return true;
-			}
+	} else {
+		chrome.webNavigation.getFrame({tabId: tab.id, frameId: 0, processId: -1}, function(frame) {
+			frame && callback(frame.url);
 		});
-	});
+	}
 }

--- a/storage.js
+++ b/storage.js
@@ -271,7 +271,7 @@ function shallowCopy(obj) {
 }
 
 function equal(a, b) {
-	if (!a || !b || typeof a != "object") {
+	if (!a || !b || typeof a != "object" || typeof b != "object") {
 		return a === b;
 	}
 	if (Object.keys(a).length != Object.keys(b).length) {


### PR DESCRIPTION
* make it run on Chrome 31 again
* close #137 - fix a Chrome bug/feature (already reported, waiting for response now) which supposedly happens when several tabs were opened from a parent chrome-extension:// tab, so `styleApply` is actually received by all these tabs despite a tabId being specified.
* Editor: only attach the hotkey rerouter if a CodeMirror codebox lost focus to avoid pointless execution while editing the code.
* Editor: less obtrusive CSSLint reporting in header, wait ~5s on change
  - Keep the old timeout after page init ~500ms
  - Immediately show the report in onbeforeunload and save
* background.js: isolate try-catch in a separate function wrapper because js engine can't optimize the entire function scope when it contains try-catch