### PR TITLE
Fixes

### DIFF
--- a/apply.js
+++ b/apply.js
@@ -216,6 +216,13 @@ function initObserver() {
 			getDynamicIFrames(document).forEach(addDocumentStylesToIFrame);
 			return;
 		}
+		// move the check out of current execution context
+		// because some same-domain (!) iframes fail to load when their "contentDocument" is accessed (!)
+		// namely gmail's old chat iframe talkgadget.google.com
+		setTimeout(process.bind(null, mutations), 0);
+	});
+
+	function process(mutations) {
 		for (var m = 0, ml = mutations.length; m < ml; m++) {
 			var mutation = mutations[m];
 			if (mutation.type === "childList") {
@@ -227,7 +234,7 @@ function initObserver() {
 				}
 			}
 		}
-	});
+	}
 
 	iframeObserver.start = function() {
 		// will be ignored by browser if already observing

--- a/edit.js
+++ b/edit.js
@@ -778,7 +778,7 @@ function updateLintReport(cm, delay) {
 		// by settings its internal delay to 1ms and restoring it back later
 		var lintOpt = editors[0].state.lint.options;
 		setTimeout((function(opt, delay) {
-			opt.delay = delay;
+			opt.delay = delay == 1 ? opt.delay : delay; // options object is shared between editors
 			update(this);
 		}).bind(cm, lintOpt, lintOpt.delay), delay);
 		lintOpt.delay = 1;

--- a/manage.html
+++ b/manage.html
@@ -43,6 +43,9 @@
 				width: 100%; height: 2px;
 				background-color: #fff;
 			}
+			.applies-to {
+				word-break: break-word;
+			}
 			.applies-to, .actions {
 				padding-left: 15px;
 			}

--- a/storage.js
+++ b/storage.js
@@ -189,6 +189,8 @@ var prefs = {
 		newline_between_rules: false,
 		end_with_newline: false
 	},
+	"editor.lintDelay": 500,        // lint gutter marker update delay, ms
+	"editor.lintReportDelay": 4500, // lint report update delay, ms
 
 	NO_DEFAULT_PREFERENCE: "No default preference for '%s'",
 	UNHANDLED_DATA_TYPE: "Default '%s' is of type '%s' - what should be done with it?",


### PR DESCRIPTION
* update CSSLint report ASAP once an issue is fixed by user so that the outdated report won't irritate them
* add configurable delays for the linter
* fix #142 by forcing long lines to wrap
* Don't break gmail chat iframe by iframeObserver<br>
  Apparently some same-domain (!) iframes fail to load when their "contentDocument" is accessed (!)