### PR TITLE
Implement site exclusions

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -325,6 +325,18 @@
 		"message": "Enabled",
 		"description": "Label for the enabled state of styles"
 	},
+	"styleExclusionsTitle": {
+		"message": "Locally excluded sites",
+		"description": "Title of the excluded sites section on the edit style page, shown when \"[x] Don't apply on specified sites\" is enabled"
+	},
+	"styleExclusionsLabel": {
+		"message": "Don't apply on specified sites",
+		"description": "Label for the checkbox that enables specified sites to be excluded from having the style applied"
+	},
+	"styleExclusionsSyntax": {
+		"message": "Enter one site per line using this syntax for URL, URL prefix, domain, regexp:",
+		"description": "Label for the textbox with sites to be excluded from having the style applied. "
+	},
 	"styleInstall": {
 		"message": "Install '$stylename$' into Stylish?",
 		"description": "Confirmation when installing a style",

--- a/apply.js
+++ b/apply.js
@@ -30,12 +30,21 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
 			break;
 		case "styleUpdated":
 			if (request.style.enabled == "true") {
-				retireStyle(request.style.id);
-				// fallthrough to "styleAdded"
+				var id = request.style.id;
+				chrome.extension.sendMessage({
+					method: "getStyles", matchUrl: location.href, id: id, asHash: true, excluded: true
+				}, function(styleHash) {
+					if (styleHash.excluded) {
+						removeStyle(id, document);
+					} else {
+						retireStyle(id);
+						applyStyles(styleHash);
+					}
+				});
 			} else {
 				removeStyle(request.style.id, document);
-				break;
 			}
+			break;
 		case "styleAdded":
 			if (request.style.enabled == "true") {
 				chrome.extension.sendMessage({method: "getStyles", matchUrl: location.href, enabled: true, id: request.style.id, asHash: true}, applyStyles);

--- a/edit.html
+++ b/edit.html
@@ -36,7 +36,9 @@
 		<script src="codemirror/keymap/vim.js"></script>
 
 		<style type="text/css">
-
+			.hidden {
+				display: none;
+			}
 			body {
 				margin: 0;
 				font: 9pt arial,sans-serif;
@@ -54,11 +56,12 @@
 			#header h1 {
 				margin-top: 0;
 			}
-			#sections {
+			body > section {
 				padding-left: 18rem;
 			}
 			#sections h2 {
-				margin-top: 0.5rem;
+				margin-top: 1rem;
+				margin-bottom: 0;
 			}
 			.aligned {
 				display: table-row;
@@ -93,7 +96,7 @@
 			#url:not([href^="http"]) {
 				display: none;
 			}
-			#enabled {
+			#enabled, #exclusions {
 				margin-left: 0;
 				vertical-align: middle;
 			}
@@ -138,6 +141,15 @@
 				counter-increment: codebox;
 				content: counter(codebox);
 				margin-left: 0.25rem;
+			}
+			/* exclusions */
+			#exclusions-section {
+				margin: 0.25rem 0 2rem;
+			}
+			#exclusions-list {
+				width: calc(100% - 0.7rem*2 - 2rem);
+				max-width: calc(100% - 0.7rem*2 - 2rem);
+				margin: 0.5rem 0 0 1.7rem;
 			}
 			/* code */
 			.code {
@@ -539,6 +551,10 @@
 					<input type="checkbox" id="enabled" class="style-contributor">
 					<label for="enabled" id="enabled-label" i18n-text="styleEnabledLabel"></label>
 				</div>
+				<div id="basic-info-exclusions">
+					<input type="checkbox" id="exclusions" class="style-contributor">
+					<label for="exclusions" id="exclusions-label" i18n-text="styleExclusionsLabel"></label>
+				</div>
 			</section>
 			<section id="actions">
 				<div>
@@ -582,6 +598,10 @@
 			</section>
 			<section id="lint"><h2 i18n-text="issues"><img id="lint-help" src="help.png" i18n-alt="helpAlt"></h2><div></div></section>
 		</div>
+		<section id="exclusions-section" class="hidden">
+			<h2 id="exclusions-heading" i18n-text="styleExclusionsTitle"><img id="exclusions-help" src="help.png" i18n-alt="helpAlt"></h2>
+			<textarea id="exclusions-list" class="style-contributor" i18n-placeholder="styleExclusionsSyntax" spellcheck="false"></textarea>
+		</section>
 		<section id="sections">
 			<h2><span id="sections-heading" i18n-text="styleSectionsTitle"></span><img id="sections-help" src="help.png" i18n-alt="helpAlt"></h2>
 		</section>

--- a/messaging.js
+++ b/messaging.js
@@ -1,8 +1,11 @@
+var frameIdMessageable;
+
 function notifyAllTabs(request) {
+	frameIdMessageable = frameIdMessageable || chrome.extension.getBackgroundPage().frameIdMessageable;
 	chrome.windows.getAll({populate: true}, function(windows) {
 		windows.forEach(function(win) {
 			win.tabs.forEach(function(tab) {
-				chrome.tabs.sendMessage(tab.id, request);
+				chrome.tabs.sendMessage(tab.id, request, frameIdMessageable ? {frameId: 0} : undefined);
 				updateIcon(tab);
 			});
 		});
@@ -53,7 +56,7 @@ function updateIcon(tab, styles) {
 		chrome.browserAction.setIcon({
 			path: {19: "19" + postfix + ".png", 38: "38" + postfix + ".png"},
 			tabId: tab.id
-		});
+		}, function() { var clearError = chrome.runtime.lastError });
 		var t = prefs.getPref("show-badge") && styles.length ? ("" + styles.length) : "";
 		chrome.browserAction.setBadgeText({text: t, tabId: tab.id});
 		chrome.browserAction.setBadgeBackgroundColor({color: disableAll ? "#aaa" : [0, 0, 0, 0]});

--- a/storage.js
+++ b/storage.js
@@ -1,6 +1,6 @@
 var stylishDb = null;
 function getDatabase(ready, error) {
-	if (stylishDb != null && stylishDb.version == "1.5") {
+	if (stylishDb != null && stylishDb.version == "1.6") {
 		ready(stylishDb);
 		return;
 	}
@@ -20,6 +20,8 @@ function getDatabase(ready, error) {
 		dbV14(stylishDb, error, ready);
 	} else if (stylishDb.version == "1.4") {
 		dbV15(stylishDb, error, ready);
+	} else if (stylishDb.version == "1.5") {
+		dbV16(stylishDb, error, ready);
 	} else {
 		ready(stylishDb);
 	}
@@ -69,7 +71,14 @@ function dbV14(d, error, done) {
 function dbV15(d, error, done) {
 	d.changeVersion(d.version, '1.5', function (t) {
 		t.executeSql('ALTER TABLE styles ADD COLUMN originalMd5 TEXT NULL;');
-	}, error, function() { dbV15(d, error, done)});
+	}, error, function() { dbV16(d, error, done)});
+}
+
+function dbV16(d, error, done) {
+	d.changeVersion(d.version, '1.6', function (t) {
+		t.executeSql('ALTER TABLE styles ADD COLUMN excludes INTEGER NULL;');
+		t.executeSql('ALTER TABLE styles ADD COLUMN excludesList TEXT NULL;');
+	}, error, function() { done(d); });
 }
 
 function enableStyle(id, enabled) {


### PR DESCRIPTION
Closes #141 

Adds site exclusion option and a textbox to list the excluded sites.

One site per line using autodetect of syntax:
- domain - only alphanumeric and dots/hyphens: `google-shmoogle.com`
- regexp - `/` at both the start and the end, optional flag `i` is supported: `/google\\.\\w{2,3}(.\\w{2,3})?\\/.*\\/inbox.*/";`
- URL - prefix starts with http/https/ftp and ends with `*`: https://google.com/mail/*
- URL - everything else `https://www.google.com/webhp`
