### PR TITLE
Editor: escape html in CSSLint report, limit message length

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -859,13 +859,17 @@ function updateLintReport(cm, delay) {
 						delete oldMarkers[pos];
 					}
 					newMarkers[pos] = info.message;
+					var message = escapeHtml(info.message.replace(/ at line \d.+$/, ""));
+					if (message.length > 100) {
+						message = message.substr(0, 100) + "...";
+					}
 					return "<tr class='" + info.severity + "'>" +
 						"<td role='severity' class='CodeMirror-lint-marker-" + info.severity + "'>" +
 							info.severity + "</td>" +
 						"<td role='line'>" + (info.from.line+1) + "</td>" +
 						"<td role='sep'>:</td>" +
 						"<td role='col'>" + (info.from.ch+1) + "</td>" +
-						"<td role='message'>" + info.message.replace(/ at line \d.+$/, "") + "</td></tr>";
+						"<td role='message'>" + message + "</td></tr>";
 				}).join("") + "</tbody>";
 			cm.state.lint.markedLast = newMarkers;
 			fixedOldIssues |= Object.keys(oldMarkers).length > 0;
@@ -884,6 +888,10 @@ function updateLintReport(cm, delay) {
 				}, CodeMirror.defaults.lintReportDelay);
 			}
 		}
+	}
+	function escapeHtml(html) {
+		var chars = {"&": "&amp;", "<": "&lt;", ">": "&gt;", '"': '&quot;', "'": '&#39;', "/": '&#x2F;'};
+		return html.replace(/[&<>"'\/]/g, function(char) { return chars[char] });
 	}
 }
 


### PR DESCRIPTION
HTML wasn't escaped in the CSSLint report, instead it was parsed and rendered as HTML.

Test case:

```css
a {
    background-image: url("data:image/svg+xml !important;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' > <polygon points='0,0 50,100 100,0' fill='#888' stroke='#000' stroke-width='1' /> </svg>");
}
```