### PR TITLE
Editor: disable "Save" button when content is unmodified

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -100,6 +100,7 @@ function setCleanItem(node, isClean) {
 function isCleanGlobal() {
 	var clean = Object.keys(dirty).length == 0;
 	setDirtyClass(document.body, !clean);
+	document.getElementById("save-button").disabled = clean;
 	return clean;
 }
 


### PR DESCRIPTION
A lot of (most?) applications disable the `Save` button when there are no changes, so this PR adds such functionality.