### PR TITLE
Add placeholders to locale files

### DIFF
--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "هل تريد تثبيت '$stylename$' في Stylish؟",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "انتقل إلى <a href='http://userstyles.org'>userstyles.org</a> للحصول على أنماط معدة مسبقًا. يمكنك طرح سؤال في <a href='http://forum.userstyles.org'>المنتدى</a> إذا كنت بحاجة للمساعدة.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "ينطبق على: $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "Are you sure you want to update '$stylename$'?",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "الأقسام",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "تعديل النمط $stylename$",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "النمط محدّث.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "أخفق التحديث - استجاب الخادم بالرمز $code$.",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "تحديد",

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "Nainstalovat '$stylename$' do Stylish?",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "Na <a href='http://userstyles.org'>userstyles.org</a> najdete již vytvořené styly. Na <a href='http://forum.userstyles.org'>fóru</a> můžete požádat o pomoc.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "Platí pro: $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "Určitě chcete aktualizovat '$stylename$'?",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "Sekce",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "Upravit Styl $stylename$",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "Styl je aktuální.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "Aktualizace selhala - server opověděl kódem $code$.",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "Specifikovat",

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "\"$stylename$\" in Stylish installieren?",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "Besuchen Sie <a href='http://userstyles.org'>userstyles.org</a> für weitere vorgefertigte Styles. Wenn Sie Hilfe benötigen, können Sie im <a href='http://forum.userstyles.org'>Forum</a> nachfragen.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "Gilt für: $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "Möchten Sie '$stylename$' wirklich aktualisieren?",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "Bereiche",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "Style $stylename$ bearbeiten",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "Der Style ist auf dem aktuellsten Stand.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "Aktualisierung fehlgeschlagen - Server hat den Fehler $code$ ausgegeben.",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "Angeben",

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "Εγκατάσταση του '$stylename$' στο Stylish;",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "Επισκεφθείτε <a href='http://userstyles.org'> userstyles.org </a> για προ-made στυλ. Ρωτήστε στο <a href='http://forum.userstyles.org'> η </a> forum αν χρειάζεστε βοήθεια.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "Ισχύει για: $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "Είστε σίγουροι ότι θέλετε να ενημερώσετε το '$stylename$';",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "Ενότητες",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "Επεξεργασία του στυλ $stylename$",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "Το στυλ είναι ενημερωμένο.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "Αποτυχία ενημέρωσης - ο διακομιστής ανταποκρίθηκε με κωδικό $code$.",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "Καθορισμός",

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "¿Quieres instalar \"$stylename$\" en Stylish?",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "Accede a la página <a href='http://userstyles.org'>userstyles.org</a> para consultar estilos desarrollados previamente. Plantea una pregunta en <a href='http://forum.userstyles.org'>el foro</a> si necesitas ayuda.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "Se aplica a: $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "¿Estás seguro de que quieres actualizar '$stylename$'?",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "Secciones",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "Editar estilo $stylename$",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "El estilo está actualizado.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "Error de actualización: el servidor ha respondido con el código $code$.",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "Especificar",

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "Asennetaanko '$stylename$' Stylishiin?",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "Käy osoitteessa <a href='http://userstyles.org'> userstyles.org</a> saadaksesi valmiita tyylejä. Kysy <a href='http://forum.userstyles.org'> foorumista </a> jos tarvitset apua.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "Kooskee: $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "Are you sure you want to update '$stylename$'?",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "Osiot",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "Muokkaa Tyyliä $stylename$",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "Tyyli on ajan tasalla.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "Päivitys epäonnistui - palvelin vastasi koodilla $code$.",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "Tarkenna",

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "Installer \"$stylename$\" dans Stylish ?",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "Pour obtenir des styles prédéfinis, rendez-vous sur <a href='http://userstyles.org'>userstyles.org</a>. Posez une question sur le <a href='http://forum.userstyles.org'>forum</a> si vous avez besoin d'aide.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "S'applique à : $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "Voulez-vous mettre à jour '$stylename$'?",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "Sections",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "Modifier le style $stylename$",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "Le style est à jour.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "Échec de la mise à jour. Le serveur a renvoyé le $code$ $code$.",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "Préciser",

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "Installare \"$stylename$\" in Stylish?",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "Visita il sito <a href='http://userstyles.org'>userstyles.org</a> per trovare stili già pronti. Utilizza <a href='http://forum.userstyles.org'>il forum</a> se hai bisogno di aiuto.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "Applica a: $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "Are you sure you want to update '$stylename$'?",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "Sezioni",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "Modifica dello stile $stylename$",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "Lo stile è aggiornato.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "Aggiornamento non riuscito - il server ha risposto con il codice $code$.",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "Specifica",

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "「$stylename$」を Stylish にインストールしますか？",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "既に作成済みのスタイルについては、<a href='http://userstyles.org'>userstyles.org</a> をご覧ください。ご質問がある場合には、<a href='http://forum.userstyles.org'>userstyles.org のフォーラム</a>でお問い合わせください。",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "適用先: $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "Are you sure you want to update '$stylename$'?",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "セクション",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "スタイル「$stylename$」を編集",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "スタイルは最新の状態です。",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "更新に失敗しました - サーバーが応答コード「$code$」を返しています。",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "個別指定",

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "'$stylename$' installeren in Stylish?",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "Bezoek <a href='http://userstyles.org'>userstyles.org</a> voor gemaakte stijlen. Stel uw vraag op <a href='http://forum.userstyles.org'>het forum</a> als u hulp nodig heeft.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "Toepasbaar op: $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "Weet u zeker dat u '$stylename$' wilt updaten?",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "Secties",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "Stijl $stylename$ bewerken",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "Stijl is up-to-date.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "Update mislukt - server gaf code $code$ als antwoord.",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "Specificeren",

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "Instalar \"$stylename$\" no Stylish?",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "Visite <a href='http://userstyles.org'>userstyles.org</a> para obter estilos pré-fabricados. Se precisar de ajuda, peça no <a href='http://forum.userstyles.org'>fórum</a>.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "Aplica-se a: $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "Are you sure you want to update '$stylename$'?",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "Seções",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "Editar estilo $stylename$",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "O estilo está atualizado.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "A atualização falhou - o  servidor respondeu com código $code$.",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "Especificar",

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "Установить \"$stylename$\" в Stylish?",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "Готовые стили можно найти на странице <a href='http://userstyles.org'>userstyles.org</a>. Если вам нужна помощь, задайте вопрос на <a href='http://forum.userstyles.org'>форуме</a>.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "Применить к: $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "Подтвердите обновление стиля '$stylename$'.",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "Разделы",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "Изменение стиля \"$stylename$\"",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "Стиль обновлен.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "Ошибка обновления: сервер вернул код \"$code$\".",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "Указать",

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "Installera '$stylename$' in i Stylish?",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "Besök <a href='http://userstyles.org'>userstyles.org</a> för färdiga stilar. Fråga i <a href='http://forum.userstyles.org'>forumet</a> om du behöver hjälp.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "Gäller för: $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "Är du säker på att du vill uppdatera '$stylename$'?",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "Sektioner",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "Ändra i Stil $stylename$",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "Stilen är fullt uppdaterad.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "Uppdateringen misslyckades - servern svarade med kod $code$.",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "Specificera",

--- a/_locales/sv_SE/messages.json
+++ b/_locales/sv_SE/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "Installera '$stylename$' in i Stylish?",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "Besök <a href='http://userstyles.org'>userstyles.org</a> för färdiga stilar. Fråga i <a href='http://forum.userstyles.org'>forumet</a> om du behöver hjälp.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "Gäller för: $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "Är du säker på att du vill uppdatera '$stylename$'?",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "Sektioner",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "Ändra i Stil $stylename$",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "Stilen är fullt uppdaterad.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "Uppdateringen misslyckades - servern svarade med kod $code$.",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "Specificera",

--- a/_locales/te/messages.json
+++ b/_locales/te/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "Install '$stylename$' into Stylish?",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "Visit <a href='http://userstyles.org'>userstyles.org</a> for pre-made styles. Ask in <a href='http://forum.userstyles.org'>the forum</a> if you need help.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "వేటికి వర్తిస్తుంది; $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "Are you sure you want to update '$stylename$'?",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "విభాగాలు",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "Edit Style $stylename$",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "Style is up to date.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "Update failed - server responded with code $code$.",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "Specify",

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "'$stylename$' Stylish'e yüklensin mi?",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "Önceden hazırlanmış stiller için <a href='http://userstyles.org'>userstyles.org</a> sitesini ziyaret edin. Yardıma ihtiyacınız olursa sorunuzu <a href='http://forum.userstyles.org'>forum</a>'da yayınlayın.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "Şuraya uygulanır: $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "Are you sure you want to update '$stylename$'?",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "Bölümler",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "$stylename$ Stilini Düzenleyin",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "Stil güncel.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "Güncellenemedi - sunucu yanıt olarak $code$ kodunu gönderdi.",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "Belirt",

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "安装 '$stylename$' 到 Stylish?",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "访问 <a href='http://userstyles.org'>userstyles.org</a> 查找预定义的样式. 如果您需要帮助，请访问 <a href='http://forum.userstyles.org'>论坛</a>.",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "应用到: $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "你確定要更新 '$stylename$' 嗎？",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "样式节",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "编辑样式 $stylename$",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "已经是最新的.",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "更新失败 - 服务器了返回代码 $code$.",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "指定站点",

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "要将“$stylename$”安装到 Stylish 中吗？",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "请访问 <a href='http://userstyles.org'>userstyles.org</a> 以获取预制样式。如果您需要帮助，请到<a href='http://forum.userstyles.org'>论坛</a>发帖提问。",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "应用对象：$applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "您确定要更新 '$stylename$'?",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "部分",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "修改样式“$stylename$”",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "样式已是最新版本。",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "更新失败 - 服务器响应代码为 $code$。",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "指定",

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -109,7 +109,12 @@
     },
     "styleInstall": {
         "message": "安裝 '$stylename$' 到 Stylish ？",
-        "description": "Confirmation when installing a style"
+        "description": "Confirmation when installing a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "manageText": {
         "message": "訪問<a href='http://userstyles.org'>userstyles.org</a> 获取現成的樣式. 如果你需要幫助，請訪問<a href='http://forum.userstyles.org' >論壇</a>。",
@@ -173,11 +178,21 @@
     },
     "appliesDisplay": {
         "message": "適用於： $applies$",
-        "description": "Text on the manage screen to describe what the style applies to"
+        "description": "Text on the manage screen to describe what the style applies to",
+        "placeholders": {
+            "applies": {
+                "content": "$1"
+            }
+        }
     },
     "styleUpdate": {
         "message": "你確定你要更新 '$stylename$' ？",
-        "description": "Confirmation when updating a style"
+        "description": "Confirmation when updating a style",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "styleSectionsTitle": {
         "message": "樣式段",
@@ -185,7 +200,12 @@
     },
     "editStyleTitle": {
         "message": "編輯樣式 $stylename$",
-        "description": "Title of the page for editing styles"
+        "description": "Title of the page for editing styles",
+        "placeholders": {
+            "stylename": {
+                "content": "$1"
+            }
+        }
     },
     "updateCheckSucceededNoUpdate": {
         "message": "樣式已是最新的。",
@@ -249,7 +269,12 @@
     },
     "updateCheckFailBadResponseCode": {
         "message": "更新失敗 – 伺服器傳回代碼 $code$ 。",
-        "description": "Text that displays when an update check failed because the response code indicates an error"
+        "description": "Text that displays when an update check failed because the response code indicates an error",
+        "placeholders": {
+            "code": {
+                "content": "$1"
+            }
+        }
     },
     "appliesSpecify": {
         "message": "指定",


### PR DESCRIPTION
@JasonBarnabe, please fix `pull_locales.rb` to autoimport the placeholders from `en/messages.json`.

Here's a python script to propagate the placeholders and use tabs for indents:

```python
#! python2
import io, os, json, re
from collections import OrderedDict

with io.open('_locales/en/messages.json', 'r', encoding='utf-8') as f:
    english_placeholders = [(k, v['placeholders']) for k,v in json.load(f).items()
                            if 'placeholders' in v]

for locale_name in os.listdir('_locales'):
    if locale_name == 'en':
        continue
    loc_path = '_locales/' + locale_name + '/messages.json'
    with io.open(loc_path, 'r+', encoding='utf-8') as f:
        loc = json.load(f, object_pairs_hook=OrderedDict)

        changed = 0
        for msgId, placeholder in english_placeholders:
            if msgId in loc and cmp(placeholder, loc[msgId].get('placeholders', None))!=0:
                loc[msgId]['placeholders'] = placeholder
                changed += 1

        if changed > 0:
            f.seek(0)
            json_str = json.dumps(loc, indent=1, ensure_ascii=False,
                                  separators=(',', ': '), encoding='utf-8')
            json_tabs = re.sub(r'^\s+', lambda s: s.group(0).replace(' ', '\t'),
                               json_str, flags=re.MULTILINE)
            f.write(json_tabs)
            f.truncate()
            print 'Placeholders added to %s: %d' % (locale_name, changed)
```