### PR TITLE
Sync prefs

### DIFF
--- a/background.html
+++ b/background.html
@@ -1,5 +1,0 @@
-<html>
-	<script src="storage.js"></script>
-	<script src="messaging.js"></script>
-	<script src="background.js"></script>
-</html>

--- a/background.js
+++ b/background.js
@@ -102,7 +102,6 @@ function disableAllStylesToggle(newState) {
 		newState = !prefs.getPref("disableAll");
 	}
 	prefs.setPref("disableAll", newState);
-	notifyAllTabs({method: "styleDisableAll", disableAll: newState});
 }
 
 function getStyles(options, callback) {

--- a/background.js
+++ b/background.js
@@ -224,6 +224,10 @@ function sectionAppliesToUrl(section, url) {
 	if (url.indexOf("http") != 0 && url.indexOf("file") != 0 && url.indexOf("chrome-extension") != 0 && url.indexOf("ftp") != 0) {
 		return false;
 	}
+	// other extensions can't be styled
+	if (url.indexOf("chrome-extension") == 0 && url.indexOf(chrome.extension.getURL("")) != 0) {
+		return false;
+	}
 	if (!section.urls && !section.domains && !section.urlPrefixes && !section.regexps) {
 		//console.log(section.id + " is global");
 		return true;

--- a/background.js
+++ b/background.js
@@ -71,7 +71,7 @@ chrome.commands.onCommand.addListener(function(command) {
 			break;
 		case "styleDisableAll":
 			disableAllStylesToggle();
-			chrome.contextMenus.update("disableAll", {checked: prefs.getPref("disableAll")});
+			chrome.contextMenus.update("disableAll", {checked: prefs.get("disableAll")});
 			break;
 	}
 });
@@ -81,11 +81,11 @@ chrome.commands.onCommand.addListener(function(command) {
 runTryCatch(function() {
 	chrome.contextMenus.create({
 		id: "show-badge", title: chrome.i18n.getMessage("menuShowBadge"),
-		type: "checkbox", contexts: ["browser_action"], checked: prefs.getPref("show-badge")
+		type: "checkbox", contexts: ["browser_action"], checked: prefs.get("show-badge")
 	}, function() { var clearError = chrome.runtime.lastError });
 	chrome.contextMenus.create({
 		id: "disableAll", title: chrome.i18n.getMessage("disableAllStyles"),
-		type: "checkbox", contexts: ["browser_action"], checked: prefs.getPref("disableAll")
+		type: "checkbox", contexts: ["browser_action"], checked: prefs.get("disableAll")
 	}, function() { var clearError = chrome.runtime.lastError });
 });
 
@@ -93,15 +93,15 @@ chrome.contextMenus.onClicked.addListener(function(info, tab) {
 	if (info.menuItemId == "disableAll") {
 		disableAllStylesToggle(info.checked);
 	} else {
-		prefs.setPref(info.menuItemId, info.checked);
+		prefs.set(info.menuItemId, info.checked);
 	}
 });
 
 function disableAllStylesToggle(newState) {
 	if (newState === undefined || newState === null) {
-		newState = !prefs.getPref("disableAll");
+		newState = !prefs.get("disableAll");
 	}
-	prefs.setPref("disableAll", newState);
+	prefs.set("disableAll", newState);
 }
 
 function getStyles(options, callback) {
@@ -114,7 +114,7 @@ function getStyles(options, callback) {
 	var asHash = "asHash" in options ? options.asHash : false;
 
 	var callCallback = function() {
-		var styles = asHash ? {disableAll: prefs.getPref("disableAll", false)} : [];
+		var styles = asHash ? {disableAll: prefs.get("disableAll", false)} : [];
 		cachedStyles.forEach(function(style) {
 			if (enabled != null && fixBoolean(style.enabled) != enabled) {
 				return;
@@ -387,7 +387,7 @@ chrome.tabs.onAttached.addListener(function(tabId, data) {
 		if (tabData.url.indexOf(editFullUrl) == 0) {
 			chrome.windows.get(tabData.windowId, {populate: true}, function(win) {
 				// If there's only one tab in this window, it's been dragged to new window
-				prefs.setPref('openEditInWindow', win.tabs.length == 1);
+				prefs.set("openEditInWindow", win.tabs.length == 1);
 			});
 		}
 	});

--- a/background.js
+++ b/background.js
@@ -35,7 +35,9 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
 		case "getStyles":
 			var styles = getStyles(request, sendResponse);
 			// check if this is a main content frame style enumeration
-			if (request.matchUrl && !request.id && sender && sender.tab && sender.frameId == 0) {
+			if (request.matchUrl && !request.id
+			&& sender && sender.tab && sender.frameId == 0
+			&& sender.tab.url == request.matchUrl) {
 				updateIcon(sender.tab, styles);
 			}
 			return true;

--- a/edit.js
+++ b/edit.js
@@ -132,16 +132,16 @@ function initCodeMirror() {
 		foldGutter: true,
 		gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter", "CodeMirror-lint-markers"],
 		matchBrackets: true,
-		lint: {getAnnotations: CodeMirror.lint.css, delay: prefs.getPref("editor.lintDelay")},
-		lintReportDelay: prefs.getPref("editor.lintReportDelay"),
+		lint: {getAnnotations: CodeMirror.lint.css, delay: prefs.get("editor.lintDelay")},
+		lintReportDelay: prefs.get("editor.lintReportDelay"),
 		styleActiveLine: true,
 		theme: "default",
-		keyMap: prefs.getPref("editor.keyMap"),
+		keyMap: prefs.get("editor.keyMap"),
 		extraKeys: { // independent of current keyMap
 			"Alt-PageDown": "nextEditor",
 			"Alt-PageUp": "prevEditor"
 		}
-	}, prefs.getPref("editor.options"));
+	}, prefs.get("editor.options"));
 
 	// additional commands
 	CM.commands.jumpToLine = jumpToLine;
@@ -219,8 +219,8 @@ function initCodeMirror() {
 		});
 	}
 
-	// preload the theme so that CodeMirror can calculate its metrics in DOMContentLoaded->loadPrefs()
-	var theme = prefs.getPref("editor.theme");
+	// preload the theme so that CodeMirror can calculate its metrics in DOMContentLoaded->setupLivePrefs()
+	var theme = prefs.get("editor.theme");
 	document.getElementById("cm-theme").href = theme == "default" ? "" : "codemirror/theme/" + theme + ".css";
 
 	// initialize global editor controls
@@ -242,7 +242,7 @@ function initCodeMirror() {
 		}
 		document.getElementById("editor.keyMap").innerHTML = optionsHtmlFromArray(Object.keys(CM.keyMap).sort());
 		document.getElementById("options").addEventListener("change", acmeEventListener, false);
-		loadPrefs(
+		setupLivePrefs(
 			document.querySelectorAll("#options *[data-option][id^='editor.']")
 				.map(function(option) { return option.id })
 		);
@@ -270,8 +270,8 @@ function acmeEventListener(event) {
 			// use non-localized "default" internally
 			if (!value || value == "default" || value == t("defaultTheme")) {
 				value = "default";
-				if (prefs.getPref(el.id) != value) {
-					prefs.setPref(el.id, value);
+				if (prefs.get(el.id) != value) {
+					prefs.set(el.id, value);
 				}
 				themeLink.href = "";
 				el.selectedIndex = 0;
@@ -386,7 +386,7 @@ document.addEventListener("wheel", function(event) {
 
 chrome.tabs.query({currentWindow: true}, function(tabs) {
 	var windowId = tabs[0].windowId;
-	if (prefs.getPref("openEditInWindow")) {
+	if (prefs.get("openEditInWindow")) {
 		if (tabs.length == 1 && window.history.length == 1) {
 			chrome.windows.getAll(function(windows) {
 				if (windows.length > 1) {
@@ -420,7 +420,7 @@ function goBackToManage(event) {
 
 window.onbeforeunload = function() {
 	if (saveSizeOnClose) {
-		prefs.setPref("windowPosition", {
+		prefs.set("windowPosition", {
 			left: screenLeft,
 			top: screenTop,
 			width: outerWidth,
@@ -964,9 +964,9 @@ function beautify(event) {
 		script.onload = doBeautify;
 	}
 	function doBeautify() {
-		var tabs = prefs.getPref("editor.indentWithTabs");
-		var options = prefs.getPref("editor.beautify");
-		options.indent_size = tabs ? 1 : prefs.getPref("editor.tabSize");
+		var tabs = prefs.get("editor.indentWithTabs");
+		var options = prefs.get("editor.beautify");
+		options.indent_size = tabs ? 1 : prefs.get("editor.tabSize");
 		options.indent_char = tabs ? "\t" : " ";
 
 		var section = getSectionForChild(event.target);
@@ -1015,7 +1015,7 @@ function beautify(event) {
 		document.querySelector(".beautify-options").addEventListener("change", function(event) {
 			var value = event.target.selectedIndex > 0;
 			options[event.target.dataset.option] = value;
-			prefs.setPref("editor.beautify", options);
+			prefs.set("editor.beautify", options);
 			event.target.parentNode.setAttribute("newline", value.toString());
 			doBeautify();
 		});
@@ -1090,7 +1090,7 @@ function initWithStyle(style) {
 	function add() {
 		var sectionDiv = addSection(null, queue.shift());
 		maximizeCodeHeight(sectionDiv, !queue.length);
-		updateLintReport(getCodeMirrorForSection(sectionDiv), prefs.getPref("editor.lintDelay"));
+		updateLintReport(getCodeMirrorForSection(sectionDiv), prefs.get("editor.lintDelay"));
 	}
 }
 
@@ -1442,12 +1442,12 @@ function showToMozillaHelp() {
 }
 
 function showKeyMapHelp() {
-	var keyMap = mergeKeyMaps({}, prefs.getPref("editor.keyMap"), CodeMirror.defaults.extraKeys);
+	var keyMap = mergeKeyMaps({}, prefs.get("editor.keyMap"), CodeMirror.defaults.extraKeys);
 	var keyMapSorted = Object.keys(keyMap)
 		.map(function(key) { return {key: key, cmd: keyMap[key]} })
 		.concat([{key: "Shift-Ctrl-Wheel", cmd: "scrollWindow"}])
 		.sort(function(a, b) { return a.cmd < b.cmd || (a.cmd == b.cmd && a.key < b.key) ? -1 : 1 });
-	showHelp(t("cm_keyMap") + ": " + prefs.getPref("editor.keyMap"),
+	showHelp(t("cm_keyMap") + ": " + prefs.get("editor.keyMap"),
 		'<table class="keymap-list">' +
 			'<thead><tr><th><input placeholder="' + t("helpKeyMapHotkey") + '" type="search"></th>' +
 				'<th><input placeholder="' + t("helpKeyMapCommand") + '" type="search"></th></tr></thead>' +
@@ -1564,8 +1564,8 @@ function showCodeMirrorPopup(title, html, options) {
 		matchBrackets: true,
 		lint: {getAnnotations: CodeMirror.lint.css, delay: 0},
 		styleActiveLine: true,
-		theme: prefs.getPref("editor.theme"),
-		keyMap: prefs.getPref("editor.keyMap")
+		theme: prefs.get("editor.theme"),
+		keyMap: prefs.get("editor.keyMap")
 	}, options));
 	popup.codebox.focus();
 	popup.codebox.on("focus", function() { hotkeyRerouter.setState(false) });

--- a/manage.js
+++ b/manage.js
@@ -110,7 +110,7 @@ function createStyleElement(style) {
 			event.stopPropagation();
 			if (openWindow || openBackgroundTab || openForegroundTab) {
 				if (openWindow) {
-					var options = prefs.getPref('windowPosition', {});
+					var options = prefs.getPref("windowPosition");
 					options.url = url;
 					chrome.windows.create(options);
 				} else {
@@ -475,12 +475,12 @@ document.addEventListener("DOMContentLoaded", function() {
 	document.getElementById("search").addEventListener("input", searchStyles);
 	searchStyles(true); // re-apply filtering on history Back
 
-	loadPrefs({
-		"manage.onlyEnabled": false,
-		"manage.onlyEdited": false,
-		"show-badge": true,
-		"popup.stylesFirst": true
-	});
+	loadPrefs([
+		"manage.onlyEnabled",
+		"manage.onlyEdited",
+		"show-badge",
+		"popup.stylesFirst"
+	]);
 	initFilter("enabled-only", document.getElementById("manage.onlyEnabled"));
 	initFilter("edited-only", document.getElementById("manage.onlyEdited"));
 });

--- a/manage.js
+++ b/manage.js
@@ -110,7 +110,7 @@ function createStyleElement(style) {
 			event.stopPropagation();
 			if (openWindow || openBackgroundTab || openForegroundTab) {
 				if (openWindow) {
-					var options = prefs.getPref("windowPosition");
+					var options = prefs.get("windowPosition");
 					options.url = url;
 					chrome.windows.create(options);
 				} else {
@@ -475,7 +475,7 @@ document.addEventListener("DOMContentLoaded", function() {
 	document.getElementById("search").addEventListener("input", searchStyles);
 	searchStyles(true); // re-apply filtering on history Back
 
-	loadPrefs([
+	setupLivePrefs([
 		"manage.onlyEnabled",
 		"manage.onlyEdited",
 		"show-badge",

--- a/manifest.json
+++ b/manifest.json
@@ -13,6 +13,7 @@
 		"tabs",
 		"webNavigation",
 		"contextMenus",
+		"storage",
 		"http://userstyles.org/",
 		"https://userstyles.org/"
 	],

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
 		"https://userstyles.org/"
 	],
 	"background": {
-		"page": "background.html"
+		"scripts": ["messaging.js", "storage.js", "background.js"]
 	},
 	"commands": {
 	  "openManage": {

--- a/messaging.js
+++ b/messaging.js
@@ -44,13 +44,13 @@ function updateIcon(tab, styles) {
 	});
 
 	function stylesReceived(styles) {
-		var disableAll = "disableAll" in styles ? styles.disableAll : prefs.getPref("disableAll");
+		var disableAll = "disableAll" in styles ? styles.disableAll : prefs.get("disableAll");
 		var postfix = styles.length == 0 || disableAll ? "w" : "";
 		chrome.browserAction.setIcon({
 			path: {19: "19" + postfix + ".png", 38: "38" + postfix + ".png"},
 			tabId: tab.id
 		});
-		var t = prefs.getPref("show-badge") && styles.length ? ("" + styles.length) : "";
+		var t = prefs.get("show-badge") && styles.length ? ("" + styles.length) : "";
 		chrome.browserAction.setBadgeText({text: t, tabId: tab.id});
 		chrome.browserAction.setBadgeBackgroundColor({color: disableAll ? "#aaa" : [0, 0, 0, 0]});
 		//console.log("Tab " + tab.id + " (" + tab.url + ") badge text set to '" + t + "'.");

--- a/messaging.js
+++ b/messaging.js
@@ -8,11 +8,7 @@ function notifyAllTabs(request) {
 		});
 	});
 	// notify all open popups
-	// use a shallow copy since the original `request` is still being processed
-	var reqPopup = {};
-	for (var k in request) reqPopup[k] = request[k];
-	reqPopup.reason = request.method;
-	reqPopup.method = "updatePopup";
+	var reqPopup = shallowMerge({}, request, {method: "updatePopup", reason: request.method});
 	chrome.extension.sendMessage(reqPopup);
 }
 

--- a/messaging.js
+++ b/messaging.js
@@ -49,10 +49,15 @@ function updateIcon(tab, styles) {
 		chrome.browserAction.setIcon({
 			path: {19: "19" + postfix + ".png", 38: "38" + postfix + ".png"},
 			tabId: tab.id
+		}, function() {
+			// if the tab was just closed an error may occur,
+			// e.g. 'windowPosition' pref updated in edit.js::window.onbeforeunload
+			if (!chrome.runtime.lastError) {
+				var t = prefs.get("show-badge") && styles.length ? ("" + styles.length) : "";
+				chrome.browserAction.setBadgeText({text: t, tabId: tab.id});
+				chrome.browserAction.setBadgeBackgroundColor({color: disableAll ? "#aaa" : [0, 0, 0, 0]});
+			}
 		});
-		var t = prefs.get("show-badge") && styles.length ? ("" + styles.length) : "";
-		chrome.browserAction.setBadgeText({text: t, tabId: tab.id});
-		chrome.browserAction.setBadgeBackgroundColor({color: disableAll ? "#aaa" : [0, 0, 0, 0]});
 		//console.log("Tab " + tab.id + " (" + tab.url + ") badge text set to '" + t + "'.");
 	}
 }

--- a/popup.js
+++ b/popup.js
@@ -185,10 +185,6 @@ function handleDelete(id) {
 	}
 }
 
-function handleDisableAll(disableAll) {
-	installed.classList.toggle("disabled", disableAll);
-}
-
 chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
 	if (request.method == "updatePopup") {
 		switch (request.reason) {
@@ -199,12 +195,6 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
 			case "styleDeleted":
 				handleDelete(request.id);
 				break;
-			case "prefChanged":
-				if (request.prefName == "disableAll") {
-					document.getElementById("disableAll").checked = request.value;
-					handleDisableAll(request.value);
-				}
-				break;
 		}
 	}
 });
@@ -213,9 +203,7 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
 	document.getElementById(id).addEventListener("click", openLink, false);
 });
 
-loadPrefs({"disableAll": false});
-handleDisableAll(prefs.getPref("disableAll"));
 document.getElementById("disableAll").addEventListener("change", function(event) {
-	notifyAllTabs({method: "styleDisableAll", disableAll: event.target.checked});
-	handleDisableAll(event.target.checked);
+	installed.classList.toggle("disabled", prefs.getPref("disableAll"));
 });
+loadPrefs(["disableAll"]);

--- a/popup.js
+++ b/popup.js
@@ -3,7 +3,7 @@ writeStyleTemplate.className = "write-style-link";
 
 var installed = document.getElementById("installed");
 
-if (!prefs.getPref("popup.stylesFirst")) {
+if (!prefs.get("popup.stylesFirst")) {
 	document.body.insertBefore(document.querySelector("body > .actions"), installed);
 }
 
@@ -29,14 +29,14 @@ function updatePopUp(url) {
 	var urlLink = writeStyleTemplate.cloneNode(true);
 	urlLink.href = "edit.html?url-prefix=" + encodeURIComponent(url);
 	urlLink.appendChild(document.createTextNode( // switchable; default="this&nbsp;URL"
-		!prefs.getPref("popup.breadcrumbs.usePath")
+		!prefs.get("popup.breadcrumbs.usePath")
 		? t("writeStyleForURL").replace(/ /g, "\u00a0")
 		: /\/\/[^/]+\/(.*)/.exec(url)[1]
 	));
 	urlLink.title = "url-prefix(\"$\")".replace("$", url);
 	writeStyleLinks.push(urlLink);
 	document.querySelector("#write-style").appendChild(urlLink)
-	if (prefs.getPref("popup.breadcrumbs")) { // switchable; default=enabled
+	if (prefs.get("popup.breadcrumbs")) { // switchable; default=enabled
 		urlLink.addEventListener("mouseenter", function(event) { this.parentNode.classList.add("url()") }, false);
 		urlLink.addEventListener("focus", function(event) { this.parentNode.classList.add("url()") }, false);
 		urlLink.addEventListener("mouseleave", function(event) { this.parentNode.classList.remove("url()") }, false);
@@ -63,7 +63,7 @@ function updatePopUp(url) {
 		link.addEventListener("click", openLinkInTabOrWindow, false);
 		container.appendChild(link);
 	});
-	if (prefs.getPref("popup.breadcrumbs")) {
+	if (prefs.get("popup.breadcrumbs")) {
 		container.classList.add("breadcrumbs");
 		container.appendChild(container.removeChild(container.firstChild));
 	}
@@ -71,7 +71,7 @@ function updatePopUp(url) {
 }
 
 function showStyles(styles) {
-	var enabledFirst = prefs.getPref("popup.enabledFirst");
+	var enabledFirst = prefs.get("popup.enabledFirst");
 	styles.sort(function(a, b) {
 		if (enabledFirst && a.enabled !== b.enabled) return !(a.enabled < b.enabled) ? -1 : 1;
 		return a.name.localeCompare(b.name);
@@ -146,9 +146,9 @@ function getId(event) {
 
 function openLinkInTabOrWindow(event) {
 	event.preventDefault();
-	if (prefs.getPref('openEditInWindow', false)) {
+	if (prefs.get("openEditInWindow", false)) {
 		var options = {url: event.target.href}
-		var wp = prefs.getPref('windowPosition', {});
+		var wp = prefs.get("windowPosition", {});
 		for (var k in wp) options[k] = wp[k];
 		chrome.windows.create(options);
 	} else {
@@ -204,6 +204,6 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
 });
 
 document.getElementById("disableAll").addEventListener("change", function(event) {
-	installed.classList.toggle("disabled", prefs.getPref("disableAll"));
+	installed.classList.toggle("disabled", prefs.get("disableAll"));
 });
-loadPrefs(["disableAll"]);
+setupLivePrefs(["disableAll"]);


### PR DESCRIPTION
Closes #156

All setting are saved in a single object under `"settings"` key. In the future there'll be other keys for the [edited] styles, something like `"style1"`, `"style2"`, ...

* `localStorage` isn't needed now, on the first run all values are migrated, the old values are renamed to `DEPRECATED: name`.

* As for manual editing of the settings, it can be done with [Storage Area Explorer](https://chrome.google.com/webstore/detail/storage-area-explorer/ocfjjjjhkpapocigimmppepjgfdecjkb) extension.

* On extension startup the settings are read from `storage.sync` into internal variable that will be used to access the values directly, which is of course faster than the synchronous and DOM-blocking `localStorage`. Necessary `prefChanged` messages are broadcast, helps in case something dependent on prefs managed to initialize before the async `storage.sync.get` returned the data.

* `storage.onChanged` event listener does the same for any subsequent changes in `chrome.sync` automatically.

* `prefs.set` automatically syncs the settings.<br>A new eventjob via setTimeout(..., 0) is scheduled to coalesce sequential calls like `prefs.set("a",1); prefs.set("b",1);` into one sync operation.

* a `readOnlyValues` property is exposed to facilitate quick-peeking of the prefs during debugging:
![readonly](https://cloud.githubusercontent.com/assets/1310400/10481537/d67f7c8c-7279-11e5-9344-e371bbacc812.png)
