### PR TITLE
Editor: sticky .CodeMirror-active class for code boxes

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -310,8 +310,16 @@ function setupCodeMirror(textarea, index) {
 	cm.on("blur", function(cm) {
 		editors.lastActive = cm;
 		hotkeyRerouter.setState(true);
+		setTimeout(function() {
+			var cm = editors.lastActive;
+			var childFocused = cm.display.wrapper.contains(document.activeElement);
+			cm.display.wrapper.classList.toggle("CodeMirror-active", childFocused);
+		}, 0);
 	});
-	cm.on("focus", hotkeyRerouter.setState.bind(null, false));
+	cm.on("focus", function() {
+		hotkeyRerouter.setState(false);
+		cm.display.wrapper.classList.add("CodeMirror-active");
+	});
 
 	var resizeGrip = cm.display.wrapper.appendChild(document.createElement("div"));
 	resizeGrip.className = "resize-grip";

--- a/edit.js
+++ b/edit.js
@@ -608,6 +608,7 @@ function setupGlobalSearch() {
 			originalOpenDialog.call(cm, template.innerHTML, callback.bind(cb), opt);
 		};
 		setTimeout(function() { cm.openDialog = originalOpenDialog; }, 0);
+		refocusMinidialog(cm);
 	}
 
 	function focusClosestCM(activeCM) {
@@ -794,12 +795,26 @@ function setupGlobalSearch() {
 
 function jumpToLine(cm) {
 	var cur = cm.getCursor();
+	refocusMinidialog(cm);
 	cm.openDialog(template.jumpToLine.innerHTML, function(str) {
 		var m = str.match(/^\s*(\d+)(?:\s*:\s*(\d+))?\s*$/);
 		if (m) {
 			cm.setCursor(m[1] - 1, m[2] ? m[2] - 1 : cur.ch);
 		}
 	}, {value: cur.line+1});
+}
+
+function refocusMinidialog(cm) {
+	var section = getSectionForCodeMirror(cm);
+	if (!section.querySelector(".CodeMirror-dialog")) {
+		return;
+	}
+	// close the currently opened minidialog
+	cm.focus();
+	// make sure to focus the input in newly opened minidialog
+	setTimeout(function() {
+		section.querySelector(".CodeMirror-dialog").focus();
+	}, 0);
 }
 
 function nextPrevEditor(cm, direction) {


### PR DESCRIPTION
* Make `.CodeMirror-active` class stick when a child search/jump minidialog is focused unlike the built-in `.CodeMirror-focused` class. 

  Thus it'll be possible to use a custom CSS style with a recolored active code box that won't annoyingly flicker every time the search/jump-to-line dialog is invoked.

* Focus the minidialog when switching find/replace. 

 Previously, when a search minidialog was displayed and we pressed a hotkey to switch to another kind of minidialog (search <-> replace), the focus wasn't correctly preserved.