### PR TITLE
Bind only one DOMContentLoaded event

### DIFF
--- a/apply.js
+++ b/apply.js
@@ -134,9 +134,7 @@ function applyStyles(styleHash) {
 	}
 
 	if (Object.keys(g_styleElements).length) {
-		document.addEventListener("DOMContentLoaded", function() {
-			getDynamicIFrames(document).forEach(addDocumentStylesToIFrame);
-		});
+		document.addEventListener("DOMContentLoaded", addDocumentStylesToAllIFrames);
 		iframeObserver.start();
 	}
 
@@ -199,6 +197,10 @@ function addDocumentStylesToIFrame(iframe) {
 	}
 }
 
+function addDocumentStylesToAllIFrames() {
+	getDynamicIFrames(document).forEach(addDocumentStylesToIFrame);
+}
+
 // Only dynamic iframes get the parent document's styles. Other ones should get styles based on their own URLs.
 function getDynamicIFrames(doc) {
 	return Array.prototype.filter.call(doc.getElementsByTagName('iframe'), iframeIsDynamic);
@@ -253,7 +255,7 @@ function initObserver() {
 		if (mutations.length > 1000) {
 			// use a much faster method for very complex pages with 100,000 mutations
 			// (observer usually receives 1k-10k mutations per call)
-			getDynamicIFrames(document).forEach(addDocumentStylesToIFrame);
+			addDocumentStylesToAllIFrames();
 			return;
 		}
 		// move the check out of current execution context


### PR DESCRIPTION
`apply.js::applyStyles` is called multiple times during page load sequence but we only need to process DOMContentLoaded event once, so this PR <s>adds `document.DOMContentLoadedBound` flag which is local to our content script</s> uses a non-anonymous callback which prevents the duplicates from being registered. The existing behavior didn't cause any actual harm though, except for dumb redundant processing of iframe elements.