### PR TITLE
Narrow-width editor on touchscreens: toggle lint report via click

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -455,6 +455,9 @@
 				#lint > div {
 					max-height: 0;
 				}
+				#lint.collapsed > div {
+					display: none;
+				}
 				#lint:hover > div {
 					margin-top: 1em;
 					max-height: 30vh;

--- a/edit.js
+++ b/edit.js
@@ -979,6 +979,10 @@ function gotoLintIssue(event) {
 	});
 }
 
+function toggleLintReport() {
+	document.getElementById("lint").classList.toggle("collapsed");
+}
+
 function beautify(event) {
 	if (exports.css_beautify) { // thanks to csslint's definition of 'exports'
 		doBeautify();
@@ -1134,6 +1138,11 @@ function initHooks() {
 	document.getElementById("lint-help").addEventListener("click", showLintHelp);
 	document.getElementById("lint").addEventListener("click", gotoLintIssue);
 	window.addEventListener("resize", resizeLintReport);
+
+	// touch devices don't have onHover events so the element we'll be toggled via clicking (touching)
+	if ("ontouchstart" in document.body) {
+		document.querySelector("#lint h2").addEventListener("click", toggleLintReport);
+	}
 
 	setupGlobalSearch();
 	setCleanGlobal();


### PR DESCRIPTION
This is a simple implementation without any visual feedback that the action is possible, kinda hoping that it's obvious because on a touchscreen everything can be touched to interact with and thus the functionality will be naturally discovered.