### PR TITLE
Support chromium forks that have no confirm in popups

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -116,21 +116,14 @@ function enable(event, enabled) {
 }
 
 function doDelete() {
-	// Opera can't do confirms in popups
-	if (getBrowser() != "Opera") {
-		if (!confirm(t('deleteStyleConfirm'))) {
-			return;
-		}
+	// Opera/Vivaldi can't do confirms in popups
+	// so we assume the dialog wasn't displayed if time span <= 10ms
+	var confirmStart = Date.now();
+	if (!confirm(t('deleteStyleConfirm')) && Date.now() - confirmStart > 10) {
+		return;
 	}
 	var id = getId(event);
 	deleteStyle(id);
-}
-
-function getBrowser() {
-	if (navigator.userAgent.indexOf("OPR") > -1) {
-		return "Opera";
-	}
-	return "Chrome";
 }
 
 function getId(event) {


### PR DESCRIPTION
Instead of kludgy workaround based on user-agent, simply measure the time: it's gonna be 0ms when `confirm` isn't supported, but we'll check against 10ms just in case of a very slow computer or some hiccup.
