### PR TITLE
Update csslint to latest version

### DIFF
--- a/csslint/csslint.js
+++ b/csslint/csslint.js
@@ -1,17 +1,14 @@
 /*!
-CSSLint
-Copyright (c) 2015 Nicole Sullivan and Nicholas C. Zakas. All rights reserved.
-
+CSSLint v1.0.4
+Copyright (c) 2016 Nicole Sullivan and Nicholas C. Zakas. All rights reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the 'Software'), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
-
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
-
 THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -19,25 +16,23 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
 */
-/* Build: v0.10.0 07-May-2015 02:11:31 */
-var exports = exports || {};
+
 var CSSLint = (function(){
+  var module = module || {},
+      exports = exports || {};
+
 /*!
 Parser-Lib
-Copyright (c) 2009-2011 Nicholas C. Zakas. All rights reserved.
-
+Copyright (c) 2009-2016 Nicholas C. Zakas. All rights reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
-
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
-
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -45,929 +40,17 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
 */
-/* Version v0.2.5dev+PR, Build time: 6-May-2015 08:03:14 */
-var parserlib = {};
-(function(){
-
-
-/**
- * A generic base to inherit from for any object
- * that needs event handling.
- * @class EventTarget
- * @constructor
- */
-function EventTarget(){
-
-    /**
-     * The array of listeners for various events.
-     * @type Object
-     * @property _listeners
-     * @private
-     */
-    this._listeners = {};
-}
-
-EventTarget.prototype = {
-
-    //restore constructor
-    constructor: EventTarget,
-
-    /**
-     * Adds a listener for a given event type.
-     * @param {String} type The type of event to add a listener for.
-     * @param {Function} listener The function to call when the event occurs.
-     * @return {void}
-     * @method addListener
-     */
-    addListener: function(type, listener){
-        if (!this._listeners[type]){
-            this._listeners[type] = [];
-        }
-
-        this._listeners[type].push(listener);
-    },
-
-    /**
-     * Fires an event based on the passed-in object.
-     * @param {Object|String} event An object with at least a 'type' attribute
-     *      or a string indicating the event name.
-     * @return {void}
-     * @method fire
-     */
-    fire: function(event){
-        if (typeof event == "string"){
-            event = { type: event };
-        }
-        if (typeof event.target != "undefined"){
-            event.target = this;
-        }
-
-        if (typeof event.type == "undefined"){
-            throw new Error("Event object missing 'type' property.");
-        }
-
-        if (this._listeners[event.type]){
-
-            //create a copy of the array and use that so listeners can't chane
-            var listeners = this._listeners[event.type].concat();
-            for (var i=0, len=listeners.length; i < len; i++){
-                listeners[i].call(this, event);
-            }
-        }
-    },
-
-    /**
-     * Removes a listener for a given event type.
-     * @param {String} type The type of event to remove a listener from.
-     * @param {Function} listener The function to remove from the event.
-     * @return {void}
-     * @method removeListener
-     */
-    removeListener: function(type, listener){
-        if (this._listeners[type]){
-            var listeners = this._listeners[type];
-            for (var i=0, len=listeners.length; i < len; i++){
-                if (listeners[i] === listener){
-                    listeners.splice(i, 1);
-                    break;
-                }
-            }
-
-
-        }
-    }
-};
-/**
- * Convenient way to read through strings.
- * @namespace parserlib.util
- * @class StringReader
- * @constructor
- * @param {String} text The text to read.
- */
-function StringReader(text){
-
-    /**
-     * The input text with line endings normalized.
-     * @property _input
-     * @type String
-     * @private
-     */
-    this._input = text.replace(/\n\r?/g, "\n");
-
-
-    /**
-     * The row for the character to be read next.
-     * @property _line
-     * @type int
-     * @private
-     */
-    this._line = 1;
-
-
-    /**
-     * The column for the character to be read next.
-     * @property _col
-     * @type int
-     * @private
-     */
-    this._col = 1;
-
-    /**
-     * The index of the character in the input to be read next.
-     * @property _cursor
-     * @type int
-     * @private
-     */
-    this._cursor = 0;
-}
-
-StringReader.prototype = {
-
-    //restore constructor
-    constructor: StringReader,
-
-    //-------------------------------------------------------------------------
-    // Position info
-    //-------------------------------------------------------------------------
-
-    /**
-     * Returns the column of the character to be read next.
-     * @return {int} The column of the character to be read next.
-     * @method getCol
-     */
-    getCol: function(){
-        return this._col;
-    },
-
-    /**
-     * Returns the row of the character to be read next.
-     * @return {int} The row of the character to be read next.
-     * @method getLine
-     */
-    getLine: function(){
-        return this._line ;
-    },
-
-    /**
-     * Determines if you're at the end of the input.
-     * @return {Boolean} True if there's no more input, false otherwise.
-     * @method eof
-     */
-    eof: function(){
-        return (this._cursor == this._input.length);
-    },
-
-    //-------------------------------------------------------------------------
-    // Basic reading
-    //-------------------------------------------------------------------------
-
-    /**
-     * Reads the next character without advancing the cursor.
-     * @param {int} count How many characters to look ahead (default is 1).
-     * @return {String} The next character or null if there is no next character.
-     * @method peek
-     */
-    peek: function(count){
-        var c = null;
-        count = (typeof count == "undefined" ? 1 : count);
-
-        //if we're not at the end of the input...
-        if (this._cursor < this._input.length){
-
-            //get character and increment cursor and column
-            c = this._input.charAt(this._cursor + count - 1);
-        }
-
-        return c;
-    },
-
-    /**
-     * Reads the next character from the input and adjusts the row and column
-     * accordingly.
-     * @return {String} The next character or null if there is no next character.
-     * @method read
-     */
-    read: function(){
-        var c = null;
-
-        //if we're not at the end of the input...
-        if (this._cursor < this._input.length){
-
-            //if the last character was a newline, increment row count
-            //and reset column count
-            if (this._input.charAt(this._cursor) == "\n"){
-                this._line++;
-                this._col=1;
-            } else {
-                this._col++;
-            }
-
-            //get character and increment cursor and column
-            c = this._input.charAt(this._cursor++);
-        }
-
-        return c;
-    },
-
-    //-------------------------------------------------------------------------
-    // Misc
-    //-------------------------------------------------------------------------
-
-    /**
-     * Saves the current location so it can be returned to later.
-     * @method mark
-     * @return {void}
-     */
-    mark: function(){
-        this._bookmark = {
-            cursor: this._cursor,
-            line:   this._line,
-            col:    this._col
-        };
-    },
-
-    reset: function(){
-        if (this._bookmark){
-            this._cursor = this._bookmark.cursor;
-            this._line = this._bookmark.line;
-            this._col = this._bookmark.col;
-            delete this._bookmark;
-        }
-    },
-
-    //-------------------------------------------------------------------------
-    // Advanced reading
-    //-------------------------------------------------------------------------
-
-    /**
-     * Reads up to and including the given string. Throws an error if that
-     * string is not found.
-     * @param {String} pattern The string to read.
-     * @return {String} The string when it is found.
-     * @throws Error when the string pattern is not found.
-     * @method readTo
-     */
-    readTo: function(pattern){
-
-        var buffer = "",
-            c;
-
-        /*
-         * First, buffer must be the same length as the pattern.
-         * Then, buffer must end with the pattern or else reach the
-         * end of the input.
-         */
-        while (buffer.length < pattern.length || buffer.lastIndexOf(pattern) != buffer.length - pattern.length){
-            c = this.read();
-            if (c){
-                buffer += c;
-            } else {
-                throw new Error("Expected \"" + pattern + "\" at line " + this._line  + ", col " + this._col + ".");
-            }
-        }
-
-        return buffer;
-
-    },
-
-    /**
-     * Reads characters while each character causes the given
-     * filter function to return true. The function is passed
-     * in each character and either returns true to continue
-     * reading or false to stop.
-     * @param {Function} filter The function to read on each character.
-     * @return {String} The string made up of all characters that passed the
-     *      filter check.
-     * @method readWhile
-     */
-    readWhile: function(filter){
-
-        var buffer = "",
-            c = this.read();
-
-        while(c !== null && filter(c)){
-            buffer += c;
-            c = this.read();
-        }
-
-        return buffer;
-
-    },
-
-    /**
-     * Reads characters that match either text or a regular expression and
-     * returns those characters. If a match is found, the row and column
-     * are adjusted; if no match is found, the reader's state is unchanged.
-     * reading or false to stop.
-     * @param {String|RegExp} matchter If a string, then the literal string
-     *      value is searched for. If a regular expression, then any string
-     *      matching the pattern is search for.
-     * @return {String} The string made up of all characters that matched or
-     *      null if there was no match.
-     * @method readMatch
-     */
-    readMatch: function(matcher){
-
-        var source = this._input.substring(this._cursor),
-            value = null;
-
-        //if it's a string, just do a straight match
-        if (typeof matcher == "string"){
-            if (source.indexOf(matcher) === 0){
-                value = this.readCount(matcher.length);
-            }
-        } else if (matcher instanceof RegExp){
-            if (matcher.test(source)){
-                value = this.readCount(RegExp.lastMatch.length);
-            }
-        }
-
-        return value;
-    },
-
-
-    /**
-     * Reads a given number of characters. If the end of the input is reached,
-     * it reads only the remaining characters and does not throw an error.
-     * @param {int} count The number of characters to read.
-     * @return {String} The string made up the read characters.
-     * @method readCount
-     */
-    readCount: function(count){
-        var buffer = "";
-
-        while(count--){
-            buffer += this.read();
-        }
-
-        return buffer;
-    }
-
-};
-
-/**
- * Type to use when a syntax error occurs.
- * @class SyntaxError
- * @namespace parserlib.util
- * @constructor
- * @param {String} message The error message.
- * @param {int} line The line at which the error occurred.
- * @param {int} col The column at which the error occurred.
- */
-function SyntaxError(message, line, col){
-
-    /**
-     * The column at which the error occurred.
-     * @type int
-     * @property col
-     */
-    this.col = col;
-
-    /**
-     * The line at which the error occurred.
-     * @type int
-     * @property line
-     */
-    this.line = line;
-
-    /**
-     * The text representation of the unit.
-     * @type String
-     * @property text
-     */
-    this.message = message;
-
-}
-
-//inherit from Error
-SyntaxError.prototype = new Error();
-/**
- * Base type to represent a single syntactic unit.
- * @class SyntaxUnit
- * @namespace parserlib.util
- * @constructor
- * @param {String} text The text of the unit.
- * @param {int} line The line of text on which the unit resides.
- * @param {int} col The column of text on which the unit resides.
- */
-function SyntaxUnit(text, line, col, type){
-
-
-    /**
-     * The column of text on which the unit resides.
-     * @type int
-     * @property col
-     */
-    this.col = col;
-
-    /**
-     * The line of text on which the unit resides.
-     * @type int
-     * @property line
-     */
-    this.line = line;
-
-    /**
-     * The text representation of the unit.
-     * @type String
-     * @property text
-     */
-    this.text = text;
-
-    /**
-     * The type of syntax unit.
-     * @type int
-     * @property type
-     */
-    this.type = type;
-}
-
-/**
- * Create a new syntax unit based solely on the given token.
- * Convenience method for creating a new syntax unit when
- * it represents a single token instead of multiple.
- * @param {Object} token The token object to represent.
- * @return {parserlib.util.SyntaxUnit} The object representing the token.
- * @static
- * @method fromToken
- */
-SyntaxUnit.fromToken = function(token){
-    return new SyntaxUnit(token.value, token.startLine, token.startCol);
-};
-
-SyntaxUnit.prototype = {
-
-    //restore constructor
-    constructor: SyntaxUnit,
-
-    /**
-     * Returns the text representation of the unit.
-     * @return {String} The text representation of the unit.
-     * @method valueOf
-     */
-    valueOf: function(){
-        return this.toString();
-    },
-
-    /**
-     * Returns the text representation of the unit.
-     * @return {String} The text representation of the unit.
-     * @method toString
-     */
-    toString: function(){
-        return this.text;
-    }
-
-};
-/*global StringReader, SyntaxError*/
-
-/**
- * Generic TokenStream providing base functionality.
- * @class TokenStreamBase
- * @namespace parserlib.util
- * @constructor
- * @param {String|StringReader} input The text to tokenize or a reader from
- *      which to read the input.
- */
-function TokenStreamBase(input, tokenData){
-
-    /**
-     * The string reader for easy access to the text.
-     * @type StringReader
-     * @property _reader
-     * @private
-     */
-    this._reader = input ? new StringReader(input.toString()) : null;
-
-    /**
-     * Token object for the last consumed token.
-     * @type Token
-     * @property _token
-     * @private
-     */
-    this._token = null;
-
-    /**
-     * The array of token information.
-     * @type Array
-     * @property _tokenData
-     * @private
-     */
-    this._tokenData = tokenData;
-
-    /**
-     * Lookahead token buffer.
-     * @type Array
-     * @property _lt
-     * @private
-     */
-    this._lt = [];
-
-    /**
-     * Lookahead token buffer index.
-     * @type int
-     * @property _ltIndex
-     * @private
-     */
-    this._ltIndex = 0;
-
-    this._ltIndexCache = [];
-}
-
-/**
- * Accepts an array of token information and outputs
- * an array of token data containing key-value mappings
- * and matching functions that the TokenStream needs.
- * @param {Array} tokens An array of token descriptors.
- * @return {Array} An array of processed token data.
- * @method createTokenData
- * @static
- */
-TokenStreamBase.createTokenData = function(tokens){
-
-    var nameMap     = [],
-        typeMap     = {},
-        tokenData     = tokens.concat([]),
-        i            = 0,
-        len            = tokenData.length+1;
-
-    tokenData.UNKNOWN = -1;
-    tokenData.unshift({name:"EOF"});
-
-    for (; i < len; i++){
-        nameMap.push(tokenData[i].name);
-        tokenData[tokenData[i].name] = i;
-        if (tokenData[i].text){
-            typeMap[tokenData[i].text] = i;
-        }
-    }
-
-    tokenData.name = function(tt){
-        return nameMap[tt];
-    };
-
-    tokenData.type = function(c){
-        return typeMap[c];
-    };
-
-    return tokenData;
-};
-
-TokenStreamBase.prototype = {
-
-    //restore constructor
-    constructor: TokenStreamBase,
-
-    //-------------------------------------------------------------------------
-    // Matching methods
-    //-------------------------------------------------------------------------
-
-    /**
-     * Determines if the next token matches the given token type.
-     * If so, that token is consumed; if not, the token is placed
-     * back onto the token stream. You can pass in any number of
-     * token types and this will return true if any of the token
-     * types is found.
-     * @param {int|int[]} tokenTypes Either a single token type or an array of
-     *      token types that the next token might be. If an array is passed,
-     *      it's assumed that the token can be any of these.
-     * @param {variant} channel (Optional) The channel to read from. If not
-     *      provided, reads from the default (unnamed) channel.
-     * @return {Boolean} True if the token type matches, false if not.
-     * @method match
-     */
-    match: function(tokenTypes, channel){
-
-        //always convert to an array, makes things easier
-        if (!(tokenTypes instanceof Array)){
-            tokenTypes = [tokenTypes];
-        }
-
-        var tt  = this.get(channel),
-            i   = 0,
-            len = tokenTypes.length;
-
-        while(i < len){
-            if (tt == tokenTypes[i++]){
-                return true;
-            }
-        }
-
-        //no match found, put the token back
-        this.unget();
-        return false;
-    },
-
-    /**
-     * Determines if the next token matches the given token type.
-     * If so, that token is consumed; if not, an error is thrown.
-     * @param {int|int[]} tokenTypes Either a single token type or an array of
-     *      token types that the next token should be. If an array is passed,
-     *      it's assumed that the token must be one of these.
-     * @param {variant} channel (Optional) The channel to read from. If not
-     *      provided, reads from the default (unnamed) channel.
-     * @return {void}
-     * @method mustMatch
-     */
-    mustMatch: function(tokenTypes, channel){
-
-        var token;
-
-        //always convert to an array, makes things easier
-        if (!(tokenTypes instanceof Array)){
-            tokenTypes = [tokenTypes];
-        }
-
-        if (!this.match.apply(this, arguments)){
-            token = this.LT(1);
-            throw new SyntaxError("Expected " + this._tokenData[tokenTypes[0]].name +
-                " at line " + token.startLine + ", col " + token.startCol + ".", token.startLine, token.startCol);
-        }
-    },
-
-    //-------------------------------------------------------------------------
-    // Consuming methods
-    //-------------------------------------------------------------------------
-
-    /**
-     * Keeps reading from the token stream until either one of the specified
-     * token types is found or until the end of the input is reached.
-     * @param {int|int[]} tokenTypes Either a single token type or an array of
-     *      token types that the next token should be. If an array is passed,
-     *      it's assumed that the token must be one of these.
-     * @param {variant} channel (Optional) The channel to read from. If not
-     *      provided, reads from the default (unnamed) channel.
-     * @return {void}
-     * @method advance
-     */
-    advance: function(tokenTypes, channel){
-
-        while(this.LA(0) !== 0 && !this.match(tokenTypes, channel)){
-            this.get();
-        }
-
-        return this.LA(0);
-    },
-
-    /**
-     * Consumes the next token from the token stream.
-     * @return {int} The token type of the token that was just consumed.
-     * @method get
-     */
-    get: function(channel){
-
-        var tokenInfo   = this._tokenData,
-            reader      = this._reader,
-            value,
-            i           =0,
-            len         = tokenInfo.length,
-            found       = false,
-            token,
-            info;
-
-        //check the lookahead buffer first
-        if (this._lt.length && this._ltIndex >= 0 && this._ltIndex < this._lt.length){
-
-            i++;
-            this._token = this._lt[this._ltIndex++];
-            info = tokenInfo[this._token.type];
-
-            //obey channels logic
-            while((info.channel !== undefined && channel !== info.channel) &&
-                    this._ltIndex < this._lt.length){
-                this._token = this._lt[this._ltIndex++];
-                info = tokenInfo[this._token.type];
-                i++;
-            }
-
-            //here be dragons
-            if ((info.channel === undefined || channel === info.channel) &&
-                    this._ltIndex <= this._lt.length){
-                this._ltIndexCache.push(i);
-                return this._token.type;
-            }
-        }
-
-        //call token retriever method
-        token = this._getToken();
-
-        //if it should be hidden, don't save a token
-        if (token.type > -1 && !tokenInfo[token.type].hide){
-
-            //apply token channel
-            token.channel = tokenInfo[token.type].channel;
-
-            //save for later
-            this._token = token;
-            this._lt.push(token);
-
-            //save space that will be moved (must be done before array is truncated)
-            this._ltIndexCache.push(this._lt.length - this._ltIndex + i);
-
-            //keep the buffer under 5 items
-            if (this._lt.length > 5){
-                this._lt.shift();
-            }
-
-            //also keep the shift buffer under 5 items
-            if (this._ltIndexCache.length > 5){
-                this._ltIndexCache.shift();
-            }
-
-            //update lookahead index
-            this._ltIndex = this._lt.length;
-        }
-
-        /*
-         * Skip to the next token if:
-         * 1. The token type is marked as hidden.
-         * 2. The token type has a channel specified and it isn't the current channel.
-         */
-        info = tokenInfo[token.type];
-        if (info &&
-                (info.hide ||
-                (info.channel !== undefined && channel !== info.channel))){
-            return this.get(channel);
-        } else {
-            //return just the type
-            return token.type;
-        }
-    },
-
-    /**
-     * Looks ahead a certain number of tokens and returns the token type at
-     * that position. This will throw an error if you lookahead past the
-     * end of input, past the size of the lookahead buffer, or back past
-     * the first token in the lookahead buffer.
-     * @param {int} The index of the token type to retrieve. 0 for the
-     *      current token, 1 for the next, -1 for the previous, etc.
-     * @return {int} The token type of the token in the given position.
-     * @method LA
-     */
-    LA: function(index){
-        var total = index,
-            tt;
-        if (index > 0){
-            //TODO: Store 5 somewhere
-            if (index > 5){
-                throw new Error("Too much lookahead.");
-            }
-
-            //get all those tokens
-            while(total){
-                tt = this.get();
-                total--;
-            }
-
-            //unget all those tokens
-            while(total < index){
-                this.unget();
-                total++;
-            }
-        } else if (index < 0){
-
-            if(this._lt[this._ltIndex+index]){
-                tt = this._lt[this._ltIndex+index].type;
-            } else {
-                throw new Error("Too much lookbehind.");
-            }
-
-        } else {
-            tt = this._token.type;
-        }
-
-        return tt;
-
-    },
-
-    /**
-     * Looks ahead a certain number of tokens and returns the token at
-     * that position. This will throw an error if you lookahead past the
-     * end of input, past the size of the lookahead buffer, or back past
-     * the first token in the lookahead buffer.
-     * @param {int} The index of the token type to retrieve. 0 for the
-     *      current token, 1 for the next, -1 for the previous, etc.
-     * @return {Object} The token of the token in the given position.
-     * @method LA
-     */
-    LT: function(index){
-
-        //lookahead first to prime the token buffer
-        this.LA(index);
-
-        //now find the token, subtract one because _ltIndex is already at the next index
-        return this._lt[this._ltIndex+index-1];
-    },
-
-    /**
-     * Returns the token type for the next token in the stream without
-     * consuming it.
-     * @return {int} The token type of the next token in the stream.
-     * @method peek
-     */
-    peek: function(){
-        return this.LA(1);
-    },
-
-    /**
-     * Returns the actual token object for the last consumed token.
-     * @return {Token} The token object for the last consumed token.
-     * @method token
-     */
-    token: function(){
-        return this._token;
-    },
-
-    /**
-     * Returns the name of the token for the given token type.
-     * @param {int} tokenType The type of token to get the name of.
-     * @return {String} The name of the token or "UNKNOWN_TOKEN" for any
-     *      invalid token type.
-     * @method tokenName
-     */
-    tokenName: function(tokenType){
-        if (tokenType < 0 || tokenType > this._tokenData.length){
-            return "UNKNOWN_TOKEN";
-        } else {
-            return this._tokenData[tokenType].name;
-        }
-    },
-
-    /**
-     * Returns the token type value for the given token name.
-     * @param {String} tokenName The name of the token whose value should be returned.
-     * @return {int} The token type value for the given token name or -1
-     *      for an unknown token.
-     * @method tokenName
-     */
-    tokenType: function(tokenName){
-        return this._tokenData[tokenName] || -1;
-    },
-
-    /**
-     * Returns the last consumed token to the token stream.
-     * @method unget
-     */
-    unget: function(){
-        //if (this._ltIndex > -1){
-        if (this._ltIndexCache.length){
-            this._ltIndex -= this._ltIndexCache.pop();//--;
-            this._token = this._lt[this._ltIndex - 1];
-        } else {
-            throw new Error("Too much lookahead.");
-        }
-    }
-
-};
-
-
-
-
-parserlib.util = {
-StringReader: StringReader,
-SyntaxError : SyntaxError,
-SyntaxUnit  : SyntaxUnit,
-EventTarget : EventTarget,
-TokenStreamBase : TokenStreamBase
-};
-})();
-
-
-/*
-Parser-Lib
-Copyright (c) 2009-2011 Nicholas C. Zakas. All rights reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-*/
-/* Version v0.2.5dev+PR, Build time: 6-May-2015 08:03:14 */
-(function(){
-var EventTarget = parserlib.util.EventTarget,
-TokenStreamBase = parserlib.util.TokenStreamBase,
-StringReader = parserlib.util.StringReader,
-SyntaxError = parserlib.util.SyntaxError,
-SyntaxUnit  = parserlib.util.SyntaxUnit;
-
-
-var Colors = {
+/* Version v1.1.0, Build time: 6-December-2016 10:31:29 */
+var parserlib = (function () {
+var require;
+require=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+"use strict";
+
+/* exported Colors */
+
+var Colors = module.exports = {
+    __proto__       :null,
     aliceblue       :"#f0f8ff",
     antiquewhite    :"#faebd7",
     aqua            :"#00ffff",
@@ -1115,7 +198,9 @@ var Colors = {
     whitesmoke      :"#f5f5f5",
     yellow          :"#ffff00",
     yellowgreen     :"#9acd32",
-    //CSS2 system colors http://www.w3.org/TR/css3-color/#css2-system
+    //'currentColor' color keyword https://www.w3.org/TR/css3-color/#currentcolor
+    currentColor        :"The value of the 'color' property.",
+    //CSS2 system colors https://www.w3.org/TR/css3-color/#css2-system
     activeBorder        :"Active window border.",
     activecaption       :"Active window caption.",
     appworkspace        :"Background color of multiple document interface.",
@@ -1146,7 +231,16 @@ var Colors = {
     windowframe         :"Window frame.",
     windowtext          :"Text in windows."
 };
-/*global SyntaxUnit, Parser*/
+
+},{}],2:[function(require,module,exports){
+"use strict";
+
+module.exports = Combinator;
+
+var SyntaxUnit = require("../util/SyntaxUnit");
+
+var Parser = require("./Parser");
+
 /**
  * Represents a selector combinator (whitespace, +, >).
  * @namespace parserlib.css
@@ -1157,7 +251,7 @@ var Colors = {
  * @param {int} line The line of text on which the unit resides.
  * @param {int} col The column of text on which the unit resides.
  */
-function Combinator(text, line, col){
+function Combinator(text, line, col) {
 
     SyntaxUnit.call(this, text, line, col, Parser.COMBINATOR_TYPE);
 
@@ -1169,13 +263,13 @@ function Combinator(text, line, col){
     this.type = "unknown";
 
     //pretty simple
-    if (/^\s+$/.test(text)){
+    if (/^\s+$/.test(text)) {
         this.type = "descendant";
-    } else if (text == ">"){
+    } else if (text === ">") {
         this.type = "child";
-    } else if (text == "+"){
+    } else if (text === "+") {
         this.type = "adjacent-sibling";
-    } else if (text == "~"){
+    } else if (text === "~") {
         this.type = "sibling";
     }
 
@@ -1185,7 +279,372 @@ Combinator.prototype = new SyntaxUnit();
 Combinator.prototype.constructor = Combinator;
 
 
-/*global SyntaxUnit, Parser*/
+},{"../util/SyntaxUnit":26,"./Parser":6}],3:[function(require,module,exports){
+"use strict";
+
+module.exports = Matcher;
+
+var StringReader = require("../util/StringReader");
+var SyntaxError = require("../util/SyntaxError");
+
+/**
+ * This class implements a combinator library for matcher functions.
+ * The combinators are described at:
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/Value_definition_syntax#Component_value_combinators
+ */
+function Matcher(matchFunc, toString) {
+    this.match = function(expression) {
+        // Save/restore marks to ensure that failed matches always restore
+        // the original location in the expression.
+        var result;
+        expression.mark();
+        result = matchFunc(expression);
+        if (result) {
+            expression.drop();
+        } else {
+            expression.restore();
+        }
+        return result;
+    };
+    this.toString = typeof toString === "function" ? toString : function() {
+        return toString;
+    };
+}
+
+/** Precedence table of combinators. */
+Matcher.prec = {
+    MOD:    5,
+    SEQ:    4,
+    ANDAND: 3,
+    OROR:   2,
+    ALT:    1
+};
+
+/** Simple recursive-descent grammar to build matchers from strings. */
+Matcher.parse = function(str) {
+    var reader, eat, expr, oror, andand, seq, mod, term, result;
+    reader = new StringReader(str);
+    eat = function(matcher) {
+        var result = reader.readMatch(matcher);
+        if (result === null) {
+            throw new SyntaxError(
+                "Expected "+matcher, reader.getLine(), reader.getCol());
+        }
+        return result;
+    };
+    expr = function() {
+        // expr = oror (" | " oror)*
+        var m = [ oror() ];
+        while (reader.readMatch(" | ") !== null) {
+            m.push(oror());
+        }
+        return m.length === 1 ? m[0] : Matcher.alt.apply(Matcher, m);
+    };
+    oror = function() {
+        // oror = andand ( " || " andand)*
+        var m = [ andand() ];
+        while (reader.readMatch(" || ") !== null) {
+            m.push(andand());
+        }
+        return m.length === 1 ? m[0] : Matcher.oror.apply(Matcher, m);
+    };
+    andand = function() {
+        // andand = seq ( " && " seq)*
+        var m = [ seq() ];
+        while (reader.readMatch(" && ") !== null) {
+            m.push(seq());
+        }
+        return m.length === 1 ? m[0] : Matcher.andand.apply(Matcher, m);
+    };
+    seq = function() {
+        // seq = mod ( " " mod)*
+        var m = [ mod() ];
+        while (reader.readMatch(/^ (?![&|\]])/) !== null) {
+            m.push(mod());
+        }
+        return m.length === 1 ? m[0] : Matcher.seq.apply(Matcher, m);
+    };
+    mod = function() {
+        // mod = term ( "?" | "*" | "+" | "#" | "{<num>,<num>}" )?
+        var m = term();
+        if (reader.readMatch("?") !== null) {
+            return m.question();
+        } else if (reader.readMatch("*") !== null) {
+            return m.star();
+        } else if (reader.readMatch("+") !== null) {
+            return m.plus();
+        } else if (reader.readMatch("#") !== null) {
+            return m.hash();
+        } else if (reader.readMatch(/^\{\s*/) !== null) {
+            var min = eat(/^\d+/);
+            eat(/^\s*,\s*/);
+            var max = eat(/^\d+/);
+            eat(/^\s*\}/);
+            return m.braces(+min, +max);
+        }
+        return m;
+    };
+    term = function() {
+        // term = <nt> | literal | "[ " expression " ]"
+        if (reader.readMatch("[ ") !== null) {
+            var m = expr();
+            eat(" ]");
+            return m;
+        }
+        return Matcher.fromType(eat(/^[^ ?*+#{]+/));
+    };
+    result = expr();
+    if (!reader.eof()) {
+        throw new SyntaxError(
+            "Expected end of string", reader.getLine(), reader.getCol());
+    }
+    return result;
+};
+
+/**
+ * Convert a string to a matcher (parsing simple alternations),
+ * or do nothing if the argument is already a matcher.
+ */
+Matcher.cast = function(m) {
+    if (m instanceof Matcher) {
+        return m;
+    }
+    return Matcher.parse(m);
+};
+
+/**
+ * Create a matcher for a single type.
+ */
+Matcher.fromType = function(type) {
+    // Late require of ValidationTypes to break a dependency cycle.
+    var ValidationTypes = require("./ValidationTypes");
+    return new Matcher(function(expression) {
+        return expression.hasNext() && ValidationTypes.isType(expression, type);
+    }, type);
+};
+
+/**
+ * Create a matcher for one or more juxtaposed words, which all must
+ * occur, in the given order.
+ */
+Matcher.seq = function() {
+    var ms = Array.prototype.slice.call(arguments).map(Matcher.cast);
+    if (ms.length === 1) {
+        return ms[0];
+    }
+    return new Matcher(function(expression) {
+        var i, result = true;
+        for (i = 0; result && i < ms.length; i++) {
+            result = ms[i].match(expression);
+        }
+        return result;
+    }, function(prec) {
+        var p = Matcher.prec.SEQ;
+        var s = ms.map(function(m) {
+            return m.toString(p);
+        }).join(" ");
+        if (prec > p) {
+            s = "[ " + s + " ]";
+        }
+        return s;
+    });
+};
+
+/**
+ * Create a matcher for one or more alternatives, where exactly one
+ * must occur.
+ */
+Matcher.alt = function() {
+    var ms = Array.prototype.slice.call(arguments).map(Matcher.cast);
+    if (ms.length === 1) {
+        return ms[0];
+    }
+    return new Matcher(function(expression) {
+        var i, result = false;
+        for (i = 0; !result && i < ms.length; i++) {
+            result = ms[i].match(expression);
+        }
+        return result;
+    }, function(prec) {
+        var p = Matcher.prec.ALT;
+        var s = ms.map(function(m) {
+            return m.toString(p);
+        }).join(" | ");
+        if (prec > p) {
+            s = "[ " + s + " ]";
+        }
+        return s;
+    });
+};
+
+/**
+ * Create a matcher for two or more options.  This implements the
+ * double bar (||) and double ampersand (&&) operators, as well as
+ * variants of && where some of the alternatives are optional.
+ * This will backtrack through even successful matches to try to
+ * maximize the number of items matched.
+ */
+Matcher.many = function(required) {
+    var ms = Array.prototype.slice.call(arguments, 1).reduce(function(acc, v) {
+        if (v.expand) {
+            // Insert all of the options for the given complex rule as
+            // individual options.
+            var ValidationTypes = require("./ValidationTypes");
+            acc.push.apply(acc, ValidationTypes.complex[v.expand].options);
+        } else {
+            acc.push(Matcher.cast(v));
+        }
+        return acc;
+    }, []);
+
+    if (required === true) {
+        required = ms.map(function() {
+            return true;
+        });
+    }
+
+    var result = new Matcher(function(expression) {
+        var seen = [], max = 0, pass = 0;
+        var success = function(matchCount) {
+            if (pass === 0) {
+                max = Math.max(matchCount, max);
+                return matchCount === ms.length;
+            } else {
+                return matchCount === max;
+            }
+        };
+        var tryMatch = function(matchCount) {
+            for (var i = 0; i < ms.length; i++) {
+                if (seen[i]) {
+                    continue;
+                }
+                expression.mark();
+                if (ms[i].match(expression)) {
+                    seen[i] = true;
+                    // Increase matchCount iff this was a required element
+                    // (or if all the elements are optional)
+                    if (tryMatch(matchCount + ((required === false || required[i]) ? 1 : 0))) {
+                        expression.drop();
+                        return true;
+                    }
+                    // Backtrack: try *not* matching using this rule, and
+                    // let's see if it leads to a better overall match.
+                    expression.restore();
+                    seen[i] = false;
+                } else {
+                    expression.drop();
+                }
+            }
+            return success(matchCount);
+        };
+        if (!tryMatch(0)) {
+            // Couldn't get a complete match, retrace our steps to make the
+            // match with the maximum # of required elements.
+            pass++;
+            tryMatch(0);
+        }
+
+        if (required === false) {
+            return max > 0;
+        }
+        // Use finer-grained specification of which matchers are required.
+        for (var i = 0; i < ms.length; i++) {
+            if (required[i] && !seen[i]) {
+                return false;
+            }
+        }
+        return true;
+    }, function(prec) {
+        var p = required === false ? Matcher.prec.OROR : Matcher.prec.ANDAND;
+        var s = ms.map(function(m, i) {
+            if (required !== false && !required[i]) {
+                return m.toString(Matcher.prec.MOD) + "?";
+            }
+            return m.toString(p);
+        }).join(required === false ? " || " : " && ");
+        if (prec > p) {
+            s = "[ " + s + " ]";
+        }
+        return s;
+    });
+    result.options = ms;
+    return result;
+};
+
+/**
+ * Create a matcher for two or more options, where all options are
+ * mandatory but they may appear in any order.
+ */
+Matcher.andand = function() {
+    var args = Array.prototype.slice.call(arguments);
+    args.unshift(true);
+    return Matcher.many.apply(Matcher, args);
+};
+
+/**
+ * Create a matcher for two or more options, where options are
+ * optional and may appear in any order, but at least one must be
+ * present.
+ */
+Matcher.oror = function() {
+    var args = Array.prototype.slice.call(arguments);
+    args.unshift(false);
+    return Matcher.many.apply(Matcher, args);
+};
+
+/** Instance methods on Matchers. */
+Matcher.prototype = {
+    constructor: Matcher,
+    // These are expected to be overridden in every instance.
+    match: function() { throw new Error("unimplemented"); },
+    toString: function() { throw new Error("unimplemented"); },
+    // This returns a standalone function to do the matching.
+    func: function() { return this.match.bind(this); },
+    // Basic combinators
+    then: function(m) { return Matcher.seq(this, m); },
+    or: function(m) { return Matcher.alt(this, m); },
+    andand: function(m) { return Matcher.many(true, this, m); },
+    oror: function(m) { return Matcher.many(false, this, m); },
+    // Component value multipliers
+    star: function() { return this.braces(0, Infinity, "*"); },
+    plus: function() { return this.braces(1, Infinity, "+"); },
+    question: function() { return this.braces(0, 1, "?"); },
+    hash: function() {
+        return this.braces(1, Infinity, "#", Matcher.cast(","));
+    },
+    braces: function(min, max, marker, optSep) {
+        var m1 = this, m2 = optSep ? optSep.then(this) : this;
+        if (!marker) {
+            marker = "{" + min + "," + max + "}";
+        }
+        return new Matcher(function(expression) {
+            var result = true, i;
+            for (i = 0; i < max; i++) {
+                if (i > 0 && optSep) {
+                    result = m2.match(expression);
+                } else {
+                    result = m1.match(expression);
+                }
+                if (!result) {
+                    break;
+                }
+            }
+            return i >= min;
+        }, function() {
+            return m1.toString(Matcher.prec.MOD) + marker;
+        });
+    }
+};
+
+},{"../util/StringReader":24,"../util/SyntaxError":25,"./ValidationTypes":21}],4:[function(require,module,exports){
+"use strict";
+
+module.exports = MediaFeature;
+
+var SyntaxUnit = require("../util/SyntaxUnit");
+
+var Parser = require("./Parser");
+
 /**
  * Represents a media feature, such as max-width:500.
  * @namespace parserlib.css
@@ -1195,7 +654,7 @@ Combinator.prototype.constructor = Combinator;
  * @param {SyntaxUnit} name The name of the feature.
  * @param {SyntaxUnit} value The value of the feature or null if none.
  */
-function MediaFeature(name, value){
+function MediaFeature(name, value) {
 
     SyntaxUnit.call(this, "(" + name + (value !== null ? ":" + value : "") + ")", name.startLine, name.startCol, Parser.MEDIA_FEATURE_TYPE);
 
@@ -1218,7 +677,15 @@ MediaFeature.prototype = new SyntaxUnit();
 MediaFeature.prototype.constructor = MediaFeature;
 
 
-/*global SyntaxUnit, Parser*/
+},{"../util/SyntaxUnit":26,"./Parser":6}],5:[function(require,module,exports){
+"use strict";
+
+module.exports = MediaQuery;
+
+var SyntaxUnit = require("../util/SyntaxUnit");
+
+var Parser = require("./Parser");
+
 /**
  * Represents an individual media query.
  * @namespace parserlib.css
@@ -1231,7 +698,7 @@ MediaFeature.prototype.constructor = MediaFeature;
  * @param {int} line The line of text on which the unit resides.
  * @param {int} col The column of text on which the unit resides.
  */
-function MediaQuery(modifier, mediaType, features, line, col){
+function MediaQuery(modifier, mediaType, features, line, col) {
 
     SyntaxUnit.call(this, (modifier ? modifier + " ": "") + (mediaType ? mediaType : "") + (mediaType && features.length > 0 ? " and " : "") + features.join(" and "), line, col, Parser.MEDIA_QUERY_TYPE);
 
@@ -1262,9 +729,27 @@ MediaQuery.prototype = new SyntaxUnit();
 MediaQuery.prototype.constructor = MediaQuery;
 
 
-/*global Tokens, TokenStream, SyntaxError, Properties, Validation, ValidationError, SyntaxUnit,
-    PropertyValue, PropertyValuePart, SelectorPart, SelectorSubPart, Selector,
-    PropertyName, Combinator, MediaFeature, MediaQuery, EventTarget */
+},{"../util/SyntaxUnit":26,"./Parser":6}],6:[function(require,module,exports){
+"use strict";
+
+module.exports = Parser;
+
+var EventTarget = require("../util/EventTarget");
+var SyntaxError = require("../util/SyntaxError");
+var SyntaxUnit = require("../util/SyntaxUnit");
+
+var Combinator = require("./Combinator");
+var MediaFeature = require("./MediaFeature");
+var MediaQuery = require("./MediaQuery");
+var PropertyName = require("./PropertyName");
+var PropertyValue = require("./PropertyValue");
+var PropertyValuePart = require("./PropertyValuePart");
+var Selector = require("./Selector");
+var SelectorPart = require("./SelectorPart");
+var SelectorSubPart = require("./SelectorSubPart");
+var TokenStream = require("./TokenStream");
+var Tokens = require("./Tokens");
+var Validation = require("./Validation");
 
 /**
  * A CSS3 parser.
@@ -1278,7 +763,7 @@ MediaQuery.prototype.constructor = MediaQuery;
  *      to indicate that IE < 8 filters should be accepted and not throw
  *      syntax errors.
  */
-function Parser(options){
+function Parser(options) {
 
     //inherit event functionality
     EventTarget.call(this);
@@ -1301,11 +786,12 @@ Parser.SELECTOR_TYPE = 7;
 Parser.SELECTOR_PART_TYPE = 8;
 Parser.SELECTOR_SUB_PART_TYPE = 9;
 
-Parser.prototype = function(){
+Parser.prototype = function() {
 
     var proto = new EventTarget(),  //new prototype
         prop,
         additions =  {
+            __proto__: null,
 
             //restore constructor
             constructor: Parser,
@@ -1326,19 +812,18 @@ Parser.prototype = function(){
             // Grammar
             //-----------------------------------------------------------------
 
-            _stylesheet: function(){
+            _stylesheet: function() {
 
                 /*
                  * stylesheet
                  *  : [ CHARSET_SYM S* STRING S* ';' ]?
                  *    [S|CDO|CDC]* [ import [S|CDO|CDC]* ]*
                  *    [ namespace [S|CDO|CDC]* ]*
-                 *    [ [ ruleset | media | page | font_face | keyframes ] [S|CDO|CDC]* ]*
+                 *    [ [ ruleset | media | page | font_face | keyframes_rule | supports_rule ] [S|CDO|CDC]* ]*
                  *  ;
                  */
 
                 var tokenStream = this._tokenStream,
-                    charset     = null,
                     count,
                     token,
                     tt;
@@ -1351,13 +836,13 @@ Parser.prototype = function(){
                 this._skipCruft();
 
                 //try to read imports - may be more than one
-                while (tokenStream.peek() == Tokens.IMPORT_SYM){
+                while (tokenStream.peek() === Tokens.IMPORT_SYM) {
                     this._import();
                     this._skipCruft();
                 }
 
                 //try to read namespaces - may be more than one
-                while (tokenStream.peek() == Tokens.NAMESPACE_SYM){
+                while (tokenStream.peek() === Tokens.NAMESPACE_SYM) {
                     this._namespace();
                     this._skipCruft();
                 }
@@ -1366,11 +851,11 @@ Parser.prototype = function(){
                 tt = tokenStream.peek();
 
                 //try to read the rest
-                while(tt > Tokens.EOF){
+                while (tt > Tokens.EOF) {
 
                     try {
 
-                        switch(tt){
+                        switch (tt) {
                             case Tokens.MEDIA_SYM:
                                 this._media();
                                 this._skipCruft();
@@ -1395,9 +880,13 @@ Parser.prototype = function(){
                                 this._document();
                                 this._skipCruft();
                                 break;
+                            case Tokens.SUPPORTS_SYM:
+                                this._supports();
+                                this._skipCruft();
+                                break;
                             case Tokens.UNKNOWN_SYM:  //unknown @ rule
                                 tokenStream.get();
-                                if (!this.options.strict){
+                                if (!this.options.strict) {
 
                                     //fire error event
                                     this.fire({
@@ -1410,11 +899,11 @@ Parser.prototype = function(){
 
                                     //skip braces
                                     count=0;
-                                    while (tokenStream.advance([Tokens.LBRACE, Tokens.RBRACE]) == Tokens.LBRACE){
+                                    while (tokenStream.advance([Tokens.LBRACE, Tokens.RBRACE]) === Tokens.LBRACE) {
                                         count++;    //keep track of nesting depth
                                     }
 
-                                    while(count){
+                                    while (count) {
                                         tokenStream.advance([Tokens.RBRACE]);
                                         count--;
                                     }
@@ -1428,10 +917,10 @@ Parser.prototype = function(){
                                 this._readWhitespace();
                                 break;
                             default:
-                                if(!this._ruleset()){
+                                if (!this._ruleset()) {
 
                                     //error handling for known issues
-                                    switch(tt){
+                                    switch (tt) {
                                         case Tokens.CHARSET_SYM:
                                             token = tokenStream.LT(1);
                                             this._charset(false);
@@ -1451,8 +940,8 @@ Parser.prototype = function(){
 
                                 }
                         }
-                    } catch(ex) {
-                        if (ex instanceof SyntaxError && !this.options.strict){
+                    } catch (ex) {
+                        if (ex instanceof SyntaxError && !this.options.strict) {
                             this.fire({
                                 type:       "error",
                                 error:      ex,
@@ -1468,21 +957,21 @@ Parser.prototype = function(){
                     tt = tokenStream.peek();
                 }
 
-                if (tt != Tokens.EOF){
+                if (tt !== Tokens.EOF) {
                     this._unexpectedToken(tokenStream.token());
                 }
 
                 this.fire("endstylesheet");
             },
 
-            _charset: function(emit){
+            _charset: function(emit) {
                 var tokenStream = this._tokenStream,
                     charset,
                     token,
                     line,
                     col;
 
-                if (tokenStream.match(Tokens.CHARSET_SYM)){
+                if (tokenStream.match(Tokens.CHARSET_SYM)) {
                     line = tokenStream.token().startLine;
                     col = tokenStream.token().startCol;
 
@@ -1495,7 +984,7 @@ Parser.prototype = function(){
                     this._readWhitespace();
                     tokenStream.mustMatch(Tokens.SEMICOLON);
 
-                    if (emit !== false){
+                    if (emit !== false) {
                         this.fire({
                             type:   "charset",
                             charset:charset,
@@ -1506,7 +995,7 @@ Parser.prototype = function(){
                 }
             },
 
-            _import: function(emit){
+            _import: function(emit) {
                 /*
                  * import
                  *   : IMPORT_SYM S*
@@ -1514,7 +1003,6 @@ Parser.prototype = function(){
                  */
 
                 var tokenStream = this._tokenStream,
-                    tt,
                     uri,
                     importToken,
                     mediaList   = [];
@@ -1537,7 +1025,7 @@ Parser.prototype = function(){
                 tokenStream.mustMatch(Tokens.SEMICOLON);
                 this._readWhitespace();
 
-                if (emit !== false){
+                if (emit !== false) {
                     this.fire({
                         type:   "import",
                         uri:    uri,
@@ -1549,7 +1037,7 @@ Parser.prototype = function(){
 
             },
 
-            _namespace: function(emit){
+            _namespace: function(emit) {
                 /*
                  * namespace
                  *   : NAMESPACE_SYM S* [namespace_prefix S*]? [STRING|URI] S* ';' S*
@@ -1568,7 +1056,7 @@ Parser.prototype = function(){
                 this._readWhitespace();
 
                 //it's a namespace prefix - no _namespace_prefix() method because it's just an IDENT
-                if (tokenStream.match(Tokens.IDENT)){
+                if (tokenStream.match(Tokens.IDENT)) {
                     prefix = tokenStream.token().value;
                     this._readWhitespace();
                 }
@@ -1587,7 +1075,7 @@ Parser.prototype = function(){
                 tokenStream.mustMatch(Tokens.SEMICOLON);
                 this._readWhitespace();
 
-                if (emit !== false){
+                if (emit !== false) {
                     this.fire({
                         type:   "namespace",
                         prefix: prefix,
@@ -1599,7 +1087,138 @@ Parser.prototype = function(){
 
             },
 
-            _media: function(){
+            _supports: function(emit) {
+                /*
+                 * supports_rule
+                 *  : SUPPORTS_SYM S* supports_condition S* group_rule_body
+                 *  ;
+                 */
+                var tokenStream = this._tokenStream,
+                    line,
+                    col;
+
+                if (tokenStream.match(Tokens.SUPPORTS_SYM)) {
+                    line = tokenStream.token().startLine;
+                    col = tokenStream.token().startCol;
+
+                    this._readWhitespace();
+                    this._supports_condition();
+                    this._readWhitespace();
+
+                    tokenStream.mustMatch(Tokens.LBRACE);
+                    this._readWhitespace();
+
+                    if (emit !== false) {
+                        this.fire({
+                            type:   "startsupports",
+                            line:   line,
+                            col:    col
+                        });
+                    }
+
+                    while (true) {
+                        if (!this._ruleset()) {
+                            break;
+                        }
+                    }
+
+                    tokenStream.mustMatch(Tokens.RBRACE);
+                    this._readWhitespace();
+
+                    this.fire({
+                        type:   "endsupports",
+                        line:   line,
+                        col:    col
+                    });
+                }
+            },
+
+            _supports_condition: function() {
+                /*
+                 * supports_condition
+                 *  : supports_negation | supports_conjunction | supports_disjunction |
+                 *    supports_condition_in_parens
+                 *  ;
+                 */
+                var tokenStream = this._tokenStream,
+                    ident;
+
+                if (tokenStream.match(Tokens.IDENT)) {
+                    ident = tokenStream.token().value.toLowerCase();
+
+                    if (ident === "not") {
+                        tokenStream.mustMatch(Tokens.S);
+                        this._supports_condition_in_parens();
+                    } else {
+                        tokenStream.unget();
+                    }
+                } else {
+                    this._supports_condition_in_parens();
+                    this._readWhitespace();
+
+                    while (tokenStream.peek() === Tokens.IDENT) {
+                        ident = tokenStream.LT(1).value.toLowerCase();
+                        if (ident === "and" || ident === "or") {
+                            tokenStream.mustMatch(Tokens.IDENT);
+                            this._readWhitespace();
+                            this._supports_condition_in_parens();
+                            this._readWhitespace();
+                        }
+                    }
+                }
+            },
+
+            _supports_condition_in_parens: function() {
+                /*
+                 * supports_condition_in_parens
+                 *  : ( '(' S* supports_condition S* ')' ) | supports_declaration_condition |
+                 *    general_enclosed
+                 *  ;
+                 */
+                var tokenStream = this._tokenStream,
+                    ident;
+
+                if (tokenStream.match(Tokens.LPAREN)) {
+                    this._readWhitespace();
+                    if (tokenStream.match(Tokens.IDENT)) {
+                        // look ahead for not keyword, if not given, continue with declaration condition.
+                        ident = tokenStream.token().value.toLowerCase();
+                        if (ident === "not") {
+                            this._readWhitespace();
+                            this._supports_condition();
+                            this._readWhitespace();
+                            tokenStream.mustMatch(Tokens.RPAREN);
+                        } else {
+                            tokenStream.unget();
+                            this._supports_declaration_condition(false);
+                        }
+                    } else {
+                        this._supports_condition();
+                        this._readWhitespace();
+                        tokenStream.mustMatch(Tokens.RPAREN);
+                    }
+                } else {
+                    this._supports_declaration_condition();
+                }
+            },
+
+            _supports_declaration_condition: function(requireStartParen) {
+                /*
+                 * supports_declaration_condition
+                 *  : '(' S* declaration ')'
+                 *  ;
+                 */
+                var tokenStream = this._tokenStream;
+
+                if (requireStartParen !== false) {
+                    tokenStream.mustMatch(Tokens.LPAREN);
+                }
+                this._readWhitespace();
+                this._declaration();
+                tokenStream.mustMatch(Tokens.RPAREN);
+            },
+
+            _media: function() {
                 /*
                  * media
                  *   : MEDIA_SYM S* media_query_list S* '{' S* ruleset* '}' S*
@@ -1629,16 +1248,20 @@ Parser.prototype = function(){
                     col:    col
                 });
 
-                while(true) {
-                    if (tokenStream.peek() == Tokens.PAGE_SYM){
+                while (true) {
+                    if (tokenStream.peek() === Tokens.PAGE_SYM) {
                         this._page();
-                    } else if (tokenStream.peek() == Tokens.FONT_FACE_SYM){
+                    } else if (tokenStream.peek() === Tokens.FONT_FACE_SYM) {
                         this._font_face();
-                    } else if (tokenStream.peek() == Tokens.VIEWPORT_SYM){
+                    } else if (tokenStream.peek() === Tokens.VIEWPORT_SYM) {
                         this._viewport();
-                    } else if (tokenStream.peek() == Tokens.DOCUMENT_SYM){
+                    } else if (tokenStream.peek() === Tokens.DOCUMENT_SYM) {
                         this._document();
-                    } else if (!this._ruleset()){
+                    } else if (tokenStream.peek() === Tokens.SUPPORTS_SYM) {
+                        this._supports();
+                    } else if (tokenStream.peek() === Tokens.MEDIA_SYM) {
+                        this._media();
+                    } else if (!this._ruleset()) {
                         break;
                     }
                 }
@@ -1656,7 +1279,7 @@ Parser.prototype = function(){
 
 
             //CSS3 Media Queries
-            _media_query_list: function(){
+            _media_query_list: function() {
                 /*
                  * media_query_list
                  *   : S* [media_query [ ',' S* media_query ]* ]?
@@ -1668,11 +1291,11 @@ Parser.prototype = function(){
 
                 this._readWhitespace();
 
-                if (tokenStream.peek() == Tokens.IDENT || tokenStream.peek() == Tokens.LPAREN){
+                if (tokenStream.peek() === Tokens.IDENT || tokenStream.peek() === Tokens.LPAREN) {
                     mediaList.push(this._media_query());
                 }
 
-                while(tokenStream.match(Tokens.COMMA)){
+                while (tokenStream.match(Tokens.COMMA)) {
                     this._readWhitespace();
                     mediaList.push(this._media_query());
                 }
@@ -1683,9 +1306,8 @@ Parser.prototype = function(){
             /*
              * Note: "expression" in the grammar maps to the _media_expression
              * method.
-
              */
-            _media_query: function(){
+            _media_query: function() {
                 /*
                  * media_query
                  *   : [ONLY | NOT]? S* media_type S* [ AND S* expression ]*
@@ -1698,11 +1320,11 @@ Parser.prototype = function(){
                     token       = null,
                     expressions = [];
 
-                if (tokenStream.match(Tokens.IDENT)){
+                if (tokenStream.match(Tokens.IDENT)) {
                     ident = tokenStream.token().value.toLowerCase();
 
                     //since there's no custom tokens for these, need to manually check
-                    if (ident != "only" && ident != "not"){
+                    if (ident !== "only" && ident !== "not") {
                         tokenStream.unget();
                         ident = null;
                     } else {
@@ -1712,24 +1334,24 @@ Parser.prototype = function(){
 
                 this._readWhitespace();
 
-                if (tokenStream.peek() == Tokens.IDENT){
+                if (tokenStream.peek() === Tokens.IDENT) {
                     type = this._media_type();
-                    if (token === null){
+                    if (token === null) {
                         token = tokenStream.token();
                     }
-                } else if (tokenStream.peek() == Tokens.LPAREN){
-                    if (token === null){
+                } else if (tokenStream.peek() === Tokens.LPAREN) {
+                    if (token === null) {
                         token = tokenStream.LT(1);
                     }
                     expressions.push(this._media_expression());
                 }
 
-                if (type === null && expressions.length === 0){
+                if (type === null && expressions.length === 0) {
                     return null;
                 } else {
                     this._readWhitespace();
-                    while (tokenStream.match(Tokens.IDENT)){
-                        if (tokenStream.token().value.toLowerCase() != "and"){
+                    while (tokenStream.match(Tokens.IDENT)) {
+                        if (tokenStream.token().value.toLowerCase() !== "and") {
                             this._unexpectedToken(tokenStream.token());
                         }
 
@@ -1742,7 +1364,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Media Queries
-            _media_type: function(){
+            _media_type: function() {
                 /*
                  * media_type
                  *   : IDENT
@@ -1759,7 +1381,7 @@ Parser.prototype = function(){
              * @method _media_expression
              * @private
              */
-            _media_expression: function(){
+            _media_expression: function() {
                 /*
                  * expression
                  *  : '(' S* media_feature S* [ ':' S* expr ]? ')' S*
@@ -1775,7 +1397,7 @@ Parser.prototype = function(){
                 feature = this._media_feature();
                 this._readWhitespace();
 
-                if (tokenStream.match(Tokens.COLON)){
+                if (tokenStream.match(Tokens.COLON)) {
                     this._readWhitespace();
                     token = tokenStream.LT(1);
                     expression = this._expression();
@@ -1784,11 +1406,11 @@ Parser.prototype = function(){
                 tokenStream.mustMatch(Tokens.RPAREN);
                 this._readWhitespace();
 
-                return new MediaFeature(feature, (expression ? new SyntaxUnit(expression, token.startLine, token.startCol) : null));
+                return new MediaFeature(feature, expression ? new SyntaxUnit(expression, token.startLine, token.startCol) : null);
             },
 
             //CSS3 Media Queries
-            _media_feature: function(){
+            _media_feature: function() {
                 /*
                  * media_feature
                  *   : IDENT
@@ -1804,7 +1426,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Paged Media
-            _page: function(){
+            _page: function() {
                 /*
                  * page:
                  *    PAGE_SYM S* IDENT? pseudo_page? S*
@@ -1824,17 +1446,17 @@ Parser.prototype = function(){
 
                 this._readWhitespace();
 
-                if (tokenStream.match(Tokens.IDENT)){
+                if (tokenStream.match(Tokens.IDENT)) {
                     identifier = tokenStream.token().value;
 
                     //The value 'auto' may not be used as a page name and MUST be treated as a syntax error.
-                    if (identifier.toLowerCase() === "auto"){
+                    if (identifier.toLowerCase() === "auto") {
                         this._unexpectedToken(tokenStream.token());
                     }
                 }
 
                 //see if there's a colon upcoming
-                if (tokenStream.peek() == Tokens.COLON){
+                if (tokenStream.peek() === Tokens.COLON) {
                     pseudoPage = this._pseudo_page();
                 }
 
@@ -1861,7 +1483,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Paged Media
-            _margin: function(){
+            _margin: function() {
                 /*
                  * margin :
                  *    margin_sym S* '{' declaration [ ';' S* declaration? ]* '}' S*
@@ -1872,7 +1494,7 @@ Parser.prototype = function(){
                     col,
                     marginSym   = this._margin_sym();
 
-                if (marginSym){
+                if (marginSym) {
                     line = tokenStream.token().startLine;
                     col = tokenStream.token().startCol;
 
@@ -1898,7 +1520,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Paged Media
-            _margin_sym: function(){
+            _margin_sym: function() {
 
                 /*
                  * margin_sym :
@@ -1923,14 +1545,13 @@ Parser.prototype = function(){
 
                 var tokenStream = this._tokenStream;
 
-                if(tokenStream.match([Tokens.TOPLEFTCORNER_SYM, Tokens.TOPLEFT_SYM,
+                if (tokenStream.match([Tokens.TOPLEFTCORNER_SYM, Tokens.TOPLEFT_SYM,
                         Tokens.TOPCENTER_SYM, Tokens.TOPRIGHT_SYM, Tokens.TOPRIGHTCORNER_SYM,
                         Tokens.BOTTOMLEFTCORNER_SYM, Tokens.BOTTOMLEFT_SYM,
                         Tokens.BOTTOMCENTER_SYM, Tokens.BOTTOMRIGHT_SYM,
                         Tokens.BOTTOMRIGHTCORNER_SYM, Tokens.LEFTTOP_SYM,
                         Tokens.LEFTMIDDLE_SYM, Tokens.LEFTBOTTOM_SYM, Tokens.RIGHTTOP_SYM,
-                        Tokens.RIGHTMIDDLE_SYM, Tokens.RIGHTBOTTOM_SYM]))
-                {
+                        Tokens.RIGHTMIDDLE_SYM, Tokens.RIGHTBOTTOM_SYM])) {
                     return SyntaxUnit.fromToken(tokenStream.token());
                 } else {
                     return null;
@@ -1938,7 +1559,7 @@ Parser.prototype = function(){
 
             },
 
-            _pseudo_page: function(){
+            _pseudo_page: function() {
                 /*
                  * pseudo_page
                  *   : ':' IDENT
@@ -1955,7 +1576,7 @@ Parser.prototype = function(){
                 return tokenStream.token().value;
             },
 
-            _font_face: function(){
+            _font_face: function() {
                 /*
                  * font_face
                  *   : FONT_FACE_SYM S*
@@ -1988,40 +1609,40 @@ Parser.prototype = function(){
                 });
             },
 
-            _viewport: function(){
+            _viewport: function() {
                 /*
                  * viewport
                  *   : VIEWPORT_SYM S*
                  *     '{' S* declaration? [ ';' S* declaration? ]* '}' S*
                  *   ;
                  */
-                 var tokenStream = this._tokenStream,
+                var tokenStream = this._tokenStream,
                     line,
                     col;
 
-                    tokenStream.mustMatch(Tokens.VIEWPORT_SYM);
-                    line = tokenStream.token().startLine;
-                    col = tokenStream.token().startCol;
+                tokenStream.mustMatch(Tokens.VIEWPORT_SYM);
+                line = tokenStream.token().startLine;
+                col = tokenStream.token().startCol;
 
-                    this._readWhitespace();
+                this._readWhitespace();
 
-                    this.fire({
-                        type:   "startviewport",
-                        line:   line,
-                        col:    col
-                    });
+                this.fire({
+                    type:   "startviewport",
+                    line:   line,
+                    col:    col
+                });
 
-                    this._readDeclarations(true);
+                this._readDeclarations(true);
 
-                    this.fire({
-                        type:   "endviewport",
-                        line:   line,
-                        col:    col
-                    });
+                this.fire({
+                    type:   "endviewport",
+                    line:   line,
+                    col:    col
+                });
 
             },
 
-            _document: function(){
+            _document: function() {
                 /*
                  * document
                  *   : DOCUMENT_SYM S*
@@ -2032,7 +1653,6 @@ Parser.prototype = function(){
 
                 var tokenStream = this._tokenStream,
                     token,
-                    tt,
                     functions = [],
                     prefix = "";
 
@@ -2045,7 +1665,7 @@ Parser.prototype = function(){
                 this._readWhitespace();
                 functions.push(this._document_function());
 
-                while(tokenStream.match(Tokens.COMMA)) {
+                while (tokenStream.match(Tokens.COMMA)) {
                     this._readWhitespace();
                     functions.push(this._document_function());
                 }
@@ -2062,18 +1682,28 @@ Parser.prototype = function(){
                 });
 
                 var ok = true;
-                while(ok) {
+                while (ok) {
                     switch (tokenStream.peek()) {
-                        case Tokens.PAGE_SYM:       this._page(); break;
-                        case Tokens.FONT_FACE_SYM:  this._font_face(); break;
-                        case Tokens.VIEWPORT_SYM:   this._viewport(); break;
-                        case Tokens.MEDIA_SYM:      this._media(); break;
-                        case Tokens.KEYFRAMES_SYM:  this._keyframes(); break;
-                        case Tokens.DOCUMENT_SYM:   this._document(); break;
+                        case Tokens.PAGE_SYM:
+                            this._page();
+                            break;
+                        case Tokens.FONT_FACE_SYM:
+                            this._font_face();
+                            break;
+                        case Tokens.VIEWPORT_SYM:
+                            this._viewport();
+                            break;
+                        case Tokens.MEDIA_SYM:
+                            this._media();
+                            break;
+                        case Tokens.KEYFRAMES_SYM:
+                            this._keyframes();
+                            break;
+                        case Tokens.DOCUMENT_SYM:
+                            this._document();
+                            break;
                         default:
-                            if (!this._ruleset()) {
-                                ok = false;
-                            }
+                            ok = Boolean(this._ruleset());
                     }
                 }
 
@@ -2090,7 +1720,7 @@ Parser.prototype = function(){
                 });
             },
 
-            _document_function: function(){
+            _document_function: function() {
                 /*
                  * document_function
                  *   : function | URI S*
@@ -2110,7 +1740,7 @@ Parser.prototype = function(){
                 return value;
             },
 
-            _operator: function(inFunction){
+            _operator: function(inFunction) {
 
                 /*
                  * operator (outside function)
@@ -2124,7 +1754,7 @@ Parser.prototype = function(){
                     token       = null;
 
                 if (tokenStream.match([Tokens.SLASH, Tokens.COMMA]) ||
-                    (inFunction && tokenStream.match([Tokens.PLUS, Tokens.STAR, Tokens.MINUS]))){
+                    (inFunction && tokenStream.match([Tokens.PLUS, Tokens.STAR, Tokens.MINUS]))) {
                     token =  tokenStream.token();
                     this._readWhitespace();
                 }
@@ -2132,7 +1762,7 @@ Parser.prototype = function(){
 
             },
 
-            _combinator: function(){
+            _combinator: function() {
 
                 /*
                  * combinator
@@ -2144,7 +1774,7 @@ Parser.prototype = function(){
                     value       = null,
                     token;
 
-                if(tokenStream.match([Tokens.PLUS, Tokens.GREATER, Tokens.TILDE])){
+                if (tokenStream.match([Tokens.PLUS, Tokens.GREATER, Tokens.TILDE])) {
                     token = tokenStream.token();
                     value = new Combinator(token.value, token.startLine, token.startCol);
                     this._readWhitespace();
@@ -2153,7 +1783,7 @@ Parser.prototype = function(){
                 return value;
             },
 
-            _unary_operator: function(){
+            _unary_operator: function() {
 
                 /*
                  * unary_operator
@@ -2163,14 +1793,14 @@ Parser.prototype = function(){
 
                 var tokenStream = this._tokenStream;
 
-                if (tokenStream.match([Tokens.MINUS, Tokens.PLUS])){
+                if (tokenStream.match([Tokens.MINUS, Tokens.PLUS])) {
                     return tokenStream.token().value;
                 } else {
                     return null;
                 }
             },
 
-            _property: function(){
+            _property: function() {
 
                 /*
                  * property
@@ -2187,7 +1817,7 @@ Parser.prototype = function(){
                     col;
 
                 //check for star hack - throws error if not allowed
-                if (tokenStream.peek() == Tokens.STAR && this.options.starHack){
+                if (tokenStream.peek() === Tokens.STAR && this.options.starHack) {
                     tokenStream.get();
                     token = tokenStream.token();
                     hack = token.value;
@@ -2195,12 +1825,12 @@ Parser.prototype = function(){
                     col = token.startCol;
                 }
 
-                if(tokenStream.match(Tokens.IDENT)){
+                if (tokenStream.match(Tokens.IDENT)) {
                     token = tokenStream.token();
                     tokenValue = token.value;
 
                     //check for underscore hack - no error if not allowed because it's valid CSS syntax
-                    if (tokenValue.charAt(0) == "_" && this.options.underscoreHack){
+                    if (tokenValue.charAt(0) === "_" && this.options.underscoreHack) {
                         hack = "_";
                         tokenValue = tokenValue.substring(1);
                     }
@@ -2213,7 +1843,7 @@ Parser.prototype = function(){
             },
 
             //Augmented with CSS3 Selectors
-            _ruleset: function(){
+            _ruleset: function() {
                 /*
                  * ruleset
                  *   : selectors_group
@@ -2232,8 +1862,8 @@ Parser.prototype = function(){
                  */
                 try {
                     selectors = this._selectors_group();
-                } catch (ex){
-                    if (ex instanceof SyntaxError && !this.options.strict){
+                } catch (ex) {
+                    if (ex instanceof SyntaxError && !this.options.strict) {
 
                         //fire error event
                         this.fire({
@@ -2246,7 +1876,7 @@ Parser.prototype = function(){
 
                         //skip over everything until closing brace
                         tt = tokenStream.advance([Tokens.RBRACE]);
-                        if (tt == Tokens.RBRACE){
+                        if (tt === Tokens.RBRACE) {
                             //if there's a right brace, the rule is finished so don't do anything
                         } else {
                             //otherwise, rethrow the error because it wasn't handled properly
@@ -2263,7 +1893,7 @@ Parser.prototype = function(){
                 }
 
                 //if it got here, all selectors parsed
-                if (selectors){
+                if (selectors) {
 
                     this.fire({
                         type:       "startrule",
@@ -2288,7 +1918,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Selectors
-            _selectors_group: function(){
+            _selectors_group: function() {
 
                 /*
                  * selectors_group
@@ -2300,13 +1930,13 @@ Parser.prototype = function(){
                     selector;
 
                 selector = this._selector();
-                if (selector !== null){
+                if (selector !== null) {
 
                     selectors.push(selector);
-                    while(tokenStream.match(Tokens.COMMA)){
+                    while (tokenStream.match(Tokens.COMMA)) {
                         this._readWhitespace();
                         selector = this._selector();
-                        if (selector !== null){
+                        if (selector !== null) {
                             selectors.push(selector);
                         } else {
                             this._unexpectedToken(tokenStream.LT(1));
@@ -2318,7 +1948,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Selectors
-            _selector: function(){
+            _selector: function() {
                 /*
                  * selector
                  *   : simple_selector_sequence [ combinator simple_selector_sequence ]*
@@ -2333,7 +1963,7 @@ Parser.prototype = function(){
 
                 //if there's no simple selector, then there's no selector
                 nextSelector = this._simple_selector_sequence();
-                if (nextSelector === null){
+                if (nextSelector === null) {
                     return null;
                 }
 
@@ -2344,12 +1974,12 @@ Parser.prototype = function(){
                     //look for a combinator
                     combinator = this._combinator();
 
-                    if (combinator !== null){
+                    if (combinator !== null) {
                         selector.push(combinator);
                         nextSelector = this._simple_selector_sequence();
 
                         //there must be a next selector
-                        if (nextSelector === null){
+                        if (nextSelector === null) {
                             this._unexpectedToken(tokenStream.LT(1));
                         } else {
 
@@ -2359,7 +1989,7 @@ Parser.prototype = function(){
                     } else {
 
                         //if there's not whitespace, we're done
-                        if (this._readWhitespace()){
+                        if (this._readWhitespace()) {
 
                             //add whitespace separator
                             ws = new Combinator(tokenStream.token().value, tokenStream.token().startLine, tokenStream.token().startCol);
@@ -2369,13 +1999,13 @@ Parser.prototype = function(){
 
                             //selector is required if there's a combinator
                             nextSelector = this._simple_selector_sequence();
-                            if (nextSelector === null){
-                                if (combinator !== null){
+                            if (nextSelector === null) {
+                                if (combinator !== null) {
                                     this._unexpectedToken(tokenStream.LT(1));
                                 }
                             } else {
 
-                                if (combinator !== null){
+                                if (combinator !== null) {
                                     selector.push(combinator);
                                 } else {
                                     selector.push(ws);
@@ -2388,13 +2018,13 @@ Parser.prototype = function(){
                         }
 
                     }
-                } while(true);
+                } while (true);
 
                 return new Selector(selector, selector[0].line, selector[0].col);
             },
 
             //CSS3 Selectors
-            _simple_selector_sequence: function(){
+            _simple_selector_sequence: function() {
                 /*
                  * simple_selector_sequence
                  *   : [ type_selector | universal ]
@@ -2415,7 +2045,7 @@ Parser.prototype = function(){
                     //the different parts after the element name to search for
                     components  = [
                         //HASH
-                        function(){
+                        function() {
                             return tokenStream.match(Tokens.HASH) ?
                                     new SelectorSubPart(tokenStream.token().value, "id", tokenStream.token().startLine, tokenStream.token().startCol) :
                                     null;
@@ -2428,7 +2058,6 @@ Parser.prototype = function(){
                     i           = 0,
                     len         = components.length,
                     component   = null,
-                    found       = false,
                     line,
                     col;
 
@@ -2438,30 +2067,30 @@ Parser.prototype = function(){
                 col = tokenStream.LT(1).startCol;
 
                 elementName = this._type_selector();
-                if (!elementName){
+                if (!elementName) {
                     elementName = this._universal();
                 }
 
-                if (elementName !== null){
+                if (elementName !== null) {
                     selectorText += elementName;
                 }
 
-                while(true){
+                while (true) {
 
                     //whitespace means we're done
-                    if (tokenStream.peek() === Tokens.S){
+                    if (tokenStream.peek() === Tokens.S) {
                         break;
                     }
 
                     //check for each component
-                    while(i < len && component === null){
+                    while (i < len && component === null) {
                         component = components[i++].call(this);
                     }
 
-                    if (component === null){
+                    if (component === null) {
 
                         //we don't have a selector
-                        if (selectorText === ""){
+                        if (selectorText === "") {
                             return null;
                         } else {
                             break;
@@ -2481,7 +2110,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Selectors
-            _type_selector: function(){
+            _type_selector: function() {
                 /*
                  * type_selector
                  *   : [ namespace_prefix ]? element_name
@@ -2492,23 +2121,23 @@ Parser.prototype = function(){
                     ns          = this._namespace_prefix(),
                     elementName = this._element_name();
 
-                if (!elementName){
+                if (!elementName) {
                     /*
                      * Need to back out the namespace that was read due to both
                      * type_selector and universal reading namespace_prefix
                      * first. Kind of hacky, but only way I can figure out
                      * right now how to not change the grammar.
                      */
-                    if (ns){
+                    if (ns) {
                         tokenStream.unget();
-                        if (ns.length > 1){
+                        if (ns.length > 1) {
                             tokenStream.unget();
                         }
                     }
 
                     return null;
                 } else {
-                    if (ns){
+                    if (ns) {
                         elementName.text = ns + elementName.text;
                         elementName.col -= ns.length;
                     }
@@ -2517,7 +2146,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Selectors
-            _class: function(){
+            _class: function() {
                 /*
                  * class
                  *   : '.' IDENT
@@ -2527,7 +2156,7 @@ Parser.prototype = function(){
                 var tokenStream = this._tokenStream,
                     token;
 
-                if (tokenStream.match(Tokens.DOT)){
+                if (tokenStream.match(Tokens.DOT)) {
                     tokenStream.mustMatch(Tokens.IDENT);
                     token = tokenStream.token();
                     return new SelectorSubPart("." + token.value, "class", token.startLine, token.startCol - 1);
@@ -2538,7 +2167,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Selectors
-            _element_name: function(){
+            _element_name: function() {
                 /*
                  * element_name
                  *   : IDENT
@@ -2548,7 +2177,7 @@ Parser.prototype = function(){
                 var tokenStream = this._tokenStream,
                     token;
 
-                if (tokenStream.match(Tokens.IDENT)){
+                if (tokenStream.match(Tokens.IDENT)) {
                     token = tokenStream.token();
                     return new SelectorSubPart(token.value, "elementName", token.startLine, token.startCol);
 
@@ -2558,7 +2187,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Selectors
-            _namespace_prefix: function(){
+            _namespace_prefix: function() {
                 /*
                  * namespace_prefix
                  *   : [ IDENT | '*' ]? '|'
@@ -2568,9 +2197,9 @@ Parser.prototype = function(){
                     value       = "";
 
                 //verify that this is a namespace prefix
-                if (tokenStream.LA(1) === Tokens.PIPE || tokenStream.LA(2) === Tokens.PIPE){
+                if (tokenStream.LA(1) === Tokens.PIPE || tokenStream.LA(2) === Tokens.PIPE) {
 
-                    if(tokenStream.match([Tokens.IDENT, Tokens.STAR])){
+                    if (tokenStream.match([Tokens.IDENT, Tokens.STAR])) {
                         value += tokenStream.token().value;
                     }
 
@@ -2583,7 +2212,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Selectors
-            _universal: function(){
+            _universal: function() {
                 /*
                  * universal
                  *   : [ namespace_prefix ]? '*'
@@ -2594,20 +2223,20 @@ Parser.prototype = function(){
                     ns;
 
                 ns = this._namespace_prefix();
-                if(ns){
+                if (ns) {
                     value += ns;
                 }
 
-                if(tokenStream.match(Tokens.STAR)){
+                if (tokenStream.match(Tokens.STAR)) {
                     value += "*";
                 }
 
                 return value.length ? value : null;
 
-           },
+            },
 
             //CSS3 Selectors
-            _attrib: function(){
+            _attrib: function() {
                 /*
                  * attrib
                  *   : '[' S* [ namespace_prefix ]? IDENT S*
@@ -2626,14 +2255,14 @@ Parser.prototype = function(){
                     ns,
                     token;
 
-                if (tokenStream.match(Tokens.LBRACKET)){
+                if (tokenStream.match(Tokens.LBRACKET)) {
                     token = tokenStream.token();
                     value = token.value;
                     value += this._readWhitespace();
 
                     ns = this._namespace_prefix();
 
-                    if (ns){
+                    if (ns) {
                         value += ns;
                     }
 
@@ -2641,8 +2270,8 @@ Parser.prototype = function(){
                     value += tokenStream.token().value;
                     value += this._readWhitespace();
 
-                    if(tokenStream.match([Tokens.PREFIXMATCH, Tokens.SUFFIXMATCH, Tokens.SUBSTRINGMATCH,
-                            Tokens.EQUALS, Tokens.INCLUDES, Tokens.DASHMATCH])){
+                    if (tokenStream.match([Tokens.PREFIXMATCH, Tokens.SUFFIXMATCH, Tokens.SUBSTRINGMATCH,
+                            Tokens.EQUALS, Tokens.INCLUDES, Tokens.DASHMATCH])) {
 
                         value += tokenStream.token().value;
                         value += this._readWhitespace();
@@ -2661,7 +2290,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Selectors
-            _pseudo: function(){
+            _pseudo: function() {
 
                 /*
                  * pseudo
@@ -2675,24 +2304,28 @@ Parser.prototype = function(){
                     line,
                     col;
 
-                if (tokenStream.match(Tokens.COLON)){
+                if (tokenStream.match(Tokens.COLON)) {
 
-                    if (tokenStream.match(Tokens.COLON)){
+                    if (tokenStream.match(Tokens.COLON)) {
                         colons += ":";
                     }
 
-                    if (tokenStream.match(Tokens.IDENT)){
+                    if (tokenStream.match(Tokens.IDENT)) {
                         pseudo = tokenStream.token().value;
                         line = tokenStream.token().startLine;
                         col = tokenStream.token().startCol - colons.length;
-                    } else if (tokenStream.peek() == Tokens.FUNCTION){
+                    } else if (tokenStream.peek() === Tokens.FUNCTION) {
                         line = tokenStream.LT(1).startLine;
                         col = tokenStream.LT(1).startCol - colons.length;
                         pseudo = this._functional_pseudo();
                     }
 
-                    if (pseudo){
+                    if (pseudo) {
                         pseudo = new SelectorSubPart(colons + pseudo, "pseudo", line, col);
+                    } else {
+                        var startLine = tokenStream.LT(1).startLine,
+                            startCol  = tokenStream.LT(0).startCol;
+                        throw new SyntaxError("Expected a `FUNCTION` or `IDENT` after colon at line " + startLine + ", col " + startCol + ".", startLine, startCol);
                     }
                 }
 
@@ -2700,7 +2333,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Selectors
-            _functional_pseudo: function(){
+            _functional_pseudo: function() {
                 /*
                  * functional_pseudo
                  *   : FUNCTION S* expression ')'
@@ -2710,7 +2343,7 @@ Parser.prototype = function(){
                 var tokenStream = this._tokenStream,
                     value = null;
 
-                if(tokenStream.match(Tokens.FUNCTION)){
+                if (tokenStream.match(Tokens.FUNCTION)) {
                     value = tokenStream.token().value;
                     value += this._readWhitespace();
                     value += this._expression();
@@ -2722,7 +2355,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Selectors
-            _expression: function(){
+            _expression: function() {
                 /*
                  * expression
                  *   : [ [ PLUS | '-' | DIMENSION | NUMBER | STRING | IDENT ] S* ]+
@@ -2732,10 +2365,10 @@ Parser.prototype = function(){
                 var tokenStream = this._tokenStream,
                     value       = "";
 
-                while(tokenStream.match([Tokens.PLUS, Tokens.MINUS, Tokens.DIMENSION,
+                while (tokenStream.match([Tokens.PLUS, Tokens.MINUS, Tokens.DIMENSION,
                         Tokens.NUMBER, Tokens.STRING, Tokens.IDENT, Tokens.LENGTH,
                         Tokens.FREQ, Tokens.ANGLE, Tokens.TIME,
-                        Tokens.RESOLUTION, Tokens.SLASH])){
+                        Tokens.RESOLUTION, Tokens.SLASH])) {
 
                     value += tokenStream.token().value;
                     value += this._readWhitespace();
@@ -2746,7 +2379,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Selectors
-            _negation: function(){
+            _negation: function() {
                 /*
                  * negation
                  *   : NOT S* negation_arg S* ')'
@@ -2760,7 +2393,7 @@ Parser.prototype = function(){
                     arg,
                     subpart     = null;
 
-                if (tokenStream.match(Tokens.NOT)){
+                if (tokenStream.match(Tokens.NOT)) {
                     value = tokenStream.token().value;
                     line = tokenStream.token().startLine;
                     col = tokenStream.token().startCol;
@@ -2779,7 +2412,7 @@ Parser.prototype = function(){
             },
 
             //CSS3 Selectors
-            _negation_arg: function(){
+            _negation_arg: function() {
                 /*
                  * negation_arg
                  *   : type_selector | universal | HASH | class | attrib | pseudo
@@ -2790,7 +2423,7 @@ Parser.prototype = function(){
                     args        = [
                         this._type_selector,
                         this._universal,
-                        function(){
+                        function() {
                             return tokenStream.match(Tokens.HASH) ?
                                     new SelectorSubPart(tokenStream.token().value, "id", tokenStream.token().startLine, tokenStream.token().startCol) :
                                     null;
@@ -2802,7 +2435,6 @@ Parser.prototype = function(){
                     arg         = null,
                     i           = 0,
                     len         = args.length,
-                    elementName,
                     line,
                     col,
                     part;
@@ -2810,19 +2442,19 @@ Parser.prototype = function(){
                 line = tokenStream.LT(1).startLine;
                 col = tokenStream.LT(1).startCol;
 
-                while(i < len && arg === null){
+                while (i < len && arg === null) {
 
                     arg = args[i].call(this);
                     i++;
                 }
 
                 //must be a negation arg
-                if (arg === null){
+                if (arg === null) {
                     this._unexpectedToken(tokenStream.LT(1));
                 }
 
                 //it's an element name
-                if (arg.type == "elementName"){
+                if (arg.type === "elementName") {
                     part = new SelectorPart(arg, [], arg.toString(), line, col);
                 } else {
                     part = new SelectorPart(null, [arg], arg.toString(), line, col);
@@ -2831,7 +2463,7 @@ Parser.prototype = function(){
                 return part;
             },
 
-            _declaration: function(){
+            _declaration: function() {
 
                 /*
                  * declaration
@@ -2844,12 +2476,11 @@ Parser.prototype = function(){
                     property    = null,
                     expr        = null,
                     prio        = null,
-                    error       = null,
                     invalid     = null,
                     propertyName= "";
 
                 property = this._property();
-                if (property !== null){
+                if (property !== null) {
 
                     tokenStream.mustMatch(Tokens.COLON);
                     this._readWhitespace();
@@ -2857,7 +2488,7 @@ Parser.prototype = function(){
                     expr = this._expr();
 
                     //if there's no parts for the value, it's an error
-                    if (!expr || expr.length === 0){
+                    if (!expr || expr.length === 0) {
                         this._unexpectedToken(tokenStream.LT(1));
                     }
 
@@ -2869,8 +2500,8 @@ Parser.prototype = function(){
                      * _property or *property as invalid properties.
                      */
                     propertyName = property.toString();
-                    if (this.options.starHack && property.hack == "*" ||
-                            this.options.underscoreHack && property.hack == "_") {
+                    if (this.options.starHack && property.hack === "*" ||
+                            this.options.underscoreHack && property.hack === "_") {
 
                         propertyName = property.text;
                     }
@@ -2897,7 +2528,7 @@ Parser.prototype = function(){
                 }
             },
 
-            _prio: function(){
+            _prio: function() {
                 /*
                  * prio
                  *   : IMPORTANT_SYM S*
@@ -2911,21 +2542,20 @@ Parser.prototype = function(){
                 return result;
             },
 
-            _expr: function(inFunction){
+            _expr: function(inFunction) {
                 /*
                  * expr
                  *   : term [ operator term ]*
                  *   ;
                  */
 
-                var tokenStream = this._tokenStream,
-                    values      = [],
-					//valueParts	= [],
+                var values      = [],
+                    //valueParts    = [],
                     value       = null,
                     operator    = null;
 
                 value = this._term(inFunction);
-                if (value !== null){
+                if (value !== null) {
 
                     values.push(value);
 
@@ -2933,33 +2563,33 @@ Parser.prototype = function(){
                         operator = this._operator(inFunction);
 
                         //if there's an operator, keep building up the value parts
-                        if (operator){
+                        if (operator) {
                             values.push(operator);
                         } /*else {
                             //if there's not an operator, you have a full value
-							values.push(new PropertyValue(valueParts, valueParts[0].line, valueParts[0].col));
-							valueParts = [];
-						}*/
+                            values.push(new PropertyValue(valueParts, valueParts[0].line, valueParts[0].col));
+                            valueParts = [];
+                        }*/
 
                         value = this._term(inFunction);
 
-                        if (value === null){
+                        if (value === null) {
                             break;
                         } else {
                             values.push(value);
                         }
-                    } while(true);
+                    } while (true);
                 }
 
-				//cleanup
-                /*if (valueParts.length){
+                //cleanup
+                /*if (valueParts.length) {
                     values.push(new PropertyValue(valueParts, valueParts[0].line, valueParts[0].col));
                 }*/
 
                 return values.length > 0 ? new PropertyValue(values, values[0].line, values[0].col) : null;
             },
 
-            _term: function(inFunction){
+            _term: function(inFunction) {
 
                 /*
                  * term
@@ -2974,33 +2604,34 @@ Parser.prototype = function(){
                     unary       = null,
                     value       = null,
                     endChar     = null,
+                    part        = null,
                     token,
                     line,
                     col;
 
                 //returns the operator or null
                 unary = this._unary_operator();
-                if (unary !== null){
+                if (unary !== null) {
                     line = tokenStream.token().startLine;
                     col = tokenStream.token().startCol;
                 }
 
                 //exception for IE filters
-                if (tokenStream.peek() == Tokens.IE_FUNCTION && this.options.ieFilters){
+                if (tokenStream.peek() === Tokens.IE_FUNCTION && this.options.ieFilters) {
 
                     value = this._ie_function();
-                    if (unary === null){
+                    if (unary === null) {
                         line = tokenStream.token().startLine;
                         col = tokenStream.token().startCol;
                     }
 
                 //see if it's a simple block
-                } else if (inFunction && tokenStream.match([Tokens.LPAREN, Tokens.LBRACE, Tokens.LBRACKET])){
+                } else if (inFunction && tokenStream.match([Tokens.LPAREN, Tokens.LBRACE, Tokens.LBRACKET])) {
 
                     token = tokenStream.token();
                     endChar = token.endChar;
                     value = token.value + this._expr(inFunction).text;
-                    if (unary === null){
+                    if (unary === null) {
                         line = tokenStream.token().startLine;
                         col = tokenStream.token().startCol;
                     }
@@ -3011,48 +2642,51 @@ Parser.prototype = function(){
                 //see if there's a simple match
                 } else if (tokenStream.match([Tokens.NUMBER, Tokens.PERCENTAGE, Tokens.LENGTH,
                         Tokens.ANGLE, Tokens.TIME,
-                        Tokens.FREQ, Tokens.STRING, Tokens.IDENT, Tokens.URI, Tokens.UNICODE_RANGE])){
+                        Tokens.FREQ, Tokens.STRING, Tokens.IDENT, Tokens.URI, Tokens.UNICODE_RANGE])) {
 
                     value = tokenStream.token().value;
-                    if (unary === null){
+                    if (unary === null) {
                         line = tokenStream.token().startLine;
                         col = tokenStream.token().startCol;
+                        // Correct potentially-inaccurate IDENT parsing in
+                        // PropertyValuePart constructor.
+                        part = PropertyValuePart.fromToken(tokenStream.token());
                     }
                     this._readWhitespace();
                 } else {
 
                     //see if it's a color
                     token = this._hexcolor();
-                    if (token === null){
+                    if (token === null) {
 
                         //if there's no unary, get the start of the next token for line/col info
-                        if (unary === null){
+                        if (unary === null) {
                             line = tokenStream.LT(1).startLine;
                             col = tokenStream.LT(1).startCol;
                         }
 
                         //has to be a function
-                        if (value === null){
+                        if (value === null) {
 
                             /*
                              * This checks for alpha(opacity=0) style of IE
                              * functions. IE_FUNCTION only presents progid: style.
                              */
-                            if (tokenStream.LA(3) == Tokens.EQUALS && this.options.ieFilters){
+                            if (tokenStream.LA(3) === Tokens.EQUALS && this.options.ieFilters) {
                                 value = this._ie_function();
                             } else {
                                 value = this._function();
                             }
                         }
 
-                        /*if (value === null){
+                        /*if (value === null) {
                             return null;
                             //throw new Error("Expected identifier at line " + tokenStream.token().startLine + ", character " +  tokenStream.token().startCol + ".");
                         }*/
 
                     } else {
                         value = token.value;
-                        if (unary === null){
+                        if (unary === null) {
                             line = token.startLine;
                             col = token.startCol;
                         }
@@ -3060,13 +2694,13 @@ Parser.prototype = function(){
 
                 }
 
-                return value !== null ?
+                return part !== null ? part : value !== null ?
                         new PropertyValuePart(unary !== null ? unary + value : value, line, col) :
                         null;
 
             },
 
-            _function: function(){
+            _function: function() {
 
                 /*
                  * function
@@ -3079,22 +2713,22 @@ Parser.prototype = function(){
                     expr        = null,
                     lt;
 
-                if (tokenStream.match(Tokens.FUNCTION)){
+                if (tokenStream.match(Tokens.FUNCTION)) {
                     functionText = tokenStream.token().value;
                     this._readWhitespace();
                     expr = this._expr(true);
                     functionText += expr;
 
                     //START: Horrible hack in case it's an IE filter
-                    if (this.options.ieFilters && tokenStream.peek() == Tokens.EQUALS){
+                    if (this.options.ieFilters && tokenStream.peek() === Tokens.EQUALS) {
                         do {
 
-                            if (this._readWhitespace()){
+                            if (this._readWhitespace()) {
                                 functionText += tokenStream.token().value;
                             }
 
                             //might be second time in the loop
-                            if (tokenStream.LA(0) == Tokens.COMMA){
+                            if (tokenStream.LA(0) === Tokens.COMMA) {
                                 functionText += tokenStream.token().value;
                             }
 
@@ -3106,12 +2740,12 @@ Parser.prototype = function(){
 
                             //functionText += this._term();
                             lt = tokenStream.peek();
-                            while(lt != Tokens.COMMA && lt != Tokens.S && lt != Tokens.RPAREN){
+                            while (lt !== Tokens.COMMA && lt !== Tokens.S && lt !== Tokens.RPAREN) {
                                 tokenStream.get();
                                 functionText += tokenStream.token().value;
                                 lt = tokenStream.peek();
                             }
-                        } while(tokenStream.match([Tokens.COMMA, Tokens.S]));
+                        } while (tokenStream.match([Tokens.COMMA, Tokens.S]));
                     }
 
                     //END: Horrible Hack
@@ -3124,7 +2758,7 @@ Parser.prototype = function(){
                 return functionText;
             },
 
-            _ie_function: function(){
+            _ie_function: function() {
 
                 /* (My own extension)
                  * ie_function
@@ -3134,21 +2768,20 @@ Parser.prototype = function(){
 
                 var tokenStream = this._tokenStream,
                     functionText = null,
-                    expr        = null,
                     lt;
 
                 //IE function can begin like a regular function, too
-                if (tokenStream.match([Tokens.IE_FUNCTION, Tokens.FUNCTION])){
+                if (tokenStream.match([Tokens.IE_FUNCTION, Tokens.FUNCTION])) {
                     functionText = tokenStream.token().value;
 
                     do {
 
-                        if (this._readWhitespace()){
+                        if (this._readWhitespace()) {
                             functionText += tokenStream.token().value;
                         }
 
                         //might be second time in the loop
-                        if (tokenStream.LA(0) == Tokens.COMMA){
+                        if (tokenStream.LA(0) === Tokens.COMMA) {
                             functionText += tokenStream.token().value;
                         }
 
@@ -3160,12 +2793,12 @@ Parser.prototype = function(){
 
                         //functionText += this._term();
                         lt = tokenStream.peek();
-                        while(lt != Tokens.COMMA && lt != Tokens.S && lt != Tokens.RPAREN){
+                        while (lt !== Tokens.COMMA && lt !== Tokens.S && lt !== Tokens.RPAREN) {
                             tokenStream.get();
                             functionText += tokenStream.token().value;
                             lt = tokenStream.peek();
                         }
-                    } while(tokenStream.match([Tokens.COMMA, Tokens.S]));
+                    } while (tokenStream.match([Tokens.COMMA, Tokens.S]));
 
                     tokenStream.match(Tokens.RPAREN);
                     functionText += ")";
@@ -3175,7 +2808,7 @@ Parser.prototype = function(){
                 return functionText;
             },
 
-            _hexcolor: function(){
+            _hexcolor: function() {
                 /*
                  * There is a constraint on the color that it must
                  * have either 3 or 6 hex-digits (i.e., [0-9a-fA-F])
@@ -3190,13 +2823,13 @@ Parser.prototype = function(){
                     token = null,
                     color;
 
-                if(tokenStream.match(Tokens.HASH)){
+                if (tokenStream.match(Tokens.HASH)) {
 
                     //need to do some validation here
 
                     token = tokenStream.token();
                     color = token.value;
-                    if (!/#[a-f0-9]{3,6}/i.test(color)){
+                    if (!/#[a-f0-9]{3,6}/i.test(color)) {
                         throw new SyntaxError("Expected a hex color but found '" + color + "' at line " + token.startLine + ", col " + token.startCol + ".", token.startLine, token.startCol);
                     }
                     this._readWhitespace();
@@ -3209,7 +2842,7 @@ Parser.prototype = function(){
             // Animations methods
             //-----------------------------------------------------------------
 
-            _keyframes: function(){
+            _keyframes: function() {
 
                 /*
                  * keyframes:
@@ -3246,7 +2879,7 @@ Parser.prototype = function(){
                 tt = tokenStream.peek();
 
                 //check for key
-                while(tt == Tokens.IDENT || tt == Tokens.PERCENTAGE) {
+                while (tt === Tokens.IDENT || tt === Tokens.PERCENTAGE) {
                     this._keyframe_rule();
                     this._readWhitespace();
                     tt = tokenStream.peek();
@@ -3266,7 +2899,7 @@ Parser.prototype = function(){
 
             },
 
-            _keyframe_name: function(){
+            _keyframe_name: function() {
 
                 /*
                  * keyframe_name:
@@ -3274,14 +2907,13 @@ Parser.prototype = function(){
                  *   | STRING
                  *   ;
                  */
-                var tokenStream = this._tokenStream,
-                    token;
+                var tokenStream = this._tokenStream;
 
                 tokenStream.mustMatch([Tokens.IDENT, Tokens.STRING]);
                 return SyntaxUnit.fromToken(tokenStream.token());
             },
 
-            _keyframe_rule: function(){
+            _keyframe_rule: function() {
 
                 /*
                  * keyframe_rule:
@@ -3289,9 +2921,7 @@ Parser.prototype = function(){
                  *     '{' S* declaration [ ';' S* declaration ]* '}' S*
                  *   ;
                  */
-                var tokenStream = this._tokenStream,
-                    token,
-                    keyList = this._key_list();
+                var keyList = this._key_list();
 
                 this.fire({
                     type:   "startkeyframerule",
@@ -3311,7 +2941,7 @@ Parser.prototype = function(){
 
             },
 
-            _key_list: function(){
+            _key_list: function() {
 
                 /*
                  * key_list:
@@ -3319,8 +2949,6 @@ Parser.prototype = function(){
                  *   ;
                  */
                 var tokenStream = this._tokenStream,
-                    token,
-                    key,
                     keyList = [];
 
                 //must be least one key
@@ -3328,7 +2956,7 @@ Parser.prototype = function(){
 
                 this._readWhitespace();
 
-                while(tokenStream.match(Tokens.COMMA)){
+                while (tokenStream.match(Tokens.COMMA)) {
                     this._readWhitespace();
                     keyList.push(this._key());
                     this._readWhitespace();
@@ -3337,7 +2965,7 @@ Parser.prototype = function(){
                 return keyList;
             },
 
-            _key: function(){
+            _key: function() {
                 /*
                  * There is a restriction that IDENT can be only "from" or "to".
                  *
@@ -3350,12 +2978,12 @@ Parser.prototype = function(){
                 var tokenStream = this._tokenStream,
                     token;
 
-                if (tokenStream.match(Tokens.PERCENTAGE)){
+                if (tokenStream.match(Tokens.PERCENTAGE)) {
                     return SyntaxUnit.fromToken(tokenStream.token());
-                } else if (tokenStream.match(Tokens.IDENT)){
+                } else if (tokenStream.match(Tokens.IDENT)) {
                     token = tokenStream.token();
 
-                    if (/from|to/i.test(token.value)){
+                    if (/from|to/i.test(token.value)) {
                         return SyntaxUnit.fromToken(token);
                     }
 
@@ -3377,8 +3005,8 @@ Parser.prototype = function(){
              * @method _skipCruft
              * @private
              */
-            _skipCruft: function(){
-                while(this._tokenStream.match([Tokens.S, Tokens.CDO, Tokens.CDC])){
+            _skipCruft: function() {
+                while (this._tokenStream.match([Tokens.S, Tokens.CDO, Tokens.CDC])) {
                     //noop
                 }
             },
@@ -3395,14 +3023,14 @@ Parser.prototype = function(){
              * @method _readDeclarations
              * @private
              */
-            _readDeclarations: function(checkStart, readMargins){
+            _readDeclarations: function(checkStart, readMargins) {
                 /*
                  * Reads the pattern
                  * S* '{' S* declaration [ ';' S* declaration ]* '}' S*
                  * or
                  * S* '{' S* [ declaration | margin ]? [ ';' S* [ declaration | margin ]? ]* '}' S*
                  * Note that this is how it is described in CSS3 Paged Media, but is actually incorrect.
-                 * A semicolon is only necessary following a declaration is there's another declaration
+                 * A semicolon is only necessary following a declaration if there's another declaration
                  * or margin afterwards.
                  */
                 var tokenStream = this._tokenStream,
@@ -3411,7 +3039,7 @@ Parser.prototype = function(){
 
                 this._readWhitespace();
 
-                if (checkStart){
+                if (checkStart) {
                     tokenStream.mustMatch(Tokens.LBRACE);
                 }
 
@@ -3419,12 +3047,12 @@ Parser.prototype = function(){
 
                 try {
 
-                    while(true){
+                    while (true) {
 
-                        if (tokenStream.match(Tokens.SEMICOLON) || (readMargins && this._margin())){
+                        if (tokenStream.match(Tokens.SEMICOLON) || (readMargins && this._margin())) {
                             //noop
-                        } else if (this._declaration()){
-                            if (!tokenStream.match(Tokens.SEMICOLON)){
+                        } else if (this._declaration()) {
+                            if (!tokenStream.match(Tokens.SEMICOLON)) {
                                 break;
                             }
                         } else {
@@ -3441,7 +3069,7 @@ Parser.prototype = function(){
                     this._readWhitespace();
 
                 } catch (ex) {
-                    if (ex instanceof SyntaxError && !this.options.strict){
+                    if (ex instanceof SyntaxError && !this.options.strict) {
 
                         //fire error event
                         this.fire({
@@ -3454,10 +3082,10 @@ Parser.prototype = function(){
 
                         //see if there's another declaration
                         tt = tokenStream.advance([Tokens.SEMICOLON, Tokens.RBRACE]);
-                        if (tt == Tokens.SEMICOLON){
+                        if (tt === Tokens.SEMICOLON) {
                             //if there's a semicolon, then there might be another declaration
                             this._readDeclarations(false, readMargins);
-                        } else if (tt != Tokens.RBRACE){
+                        } else if (tt !== Tokens.RBRACE) {
                             //if there's a right brace, the rule is finished so don't do anything
                             //otherwise, rethrow the error because it wasn't handled properly
                             throw ex;
@@ -3480,12 +3108,12 @@ Parser.prototype = function(){
              * @return {String} The white space if found, empty string if not.
              * @private
              */
-            _readWhitespace: function(){
+            _readWhitespace: function() {
 
                 var tokenStream = this._tokenStream,
                     ws = "";
 
-                while(tokenStream.match(Tokens.S)){
+                while (tokenStream.match(Tokens.S)) {
                     ws += tokenStream.token().value;
                 }
 
@@ -3500,7 +3128,7 @@ Parser.prototype = function(){
              * @return {void}
              * @private
              */
-            _unexpectedToken: function(token){
+            _unexpectedToken: function(token) {
                 throw new SyntaxError("Unexpected token '" + token.value + "' at line " + token.startLine + ", col " + token.startCol + ".", token.startLine, token.startCol);
             },
 
@@ -3510,8 +3138,8 @@ Parser.prototype = function(){
              * @method _verifyEnd
              * @private
              */
-            _verifyEnd: function(){
-                if (this._tokenStream.LA(1) != Tokens.EOF){
+            _verifyEnd: function() {
+                if (this._tokenStream.LA(1) !== Tokens.EOF) {
                     this._unexpectedToken(this._tokenStream.LT(1));
                 }
             },
@@ -3519,7 +3147,7 @@ Parser.prototype = function(){
             //-----------------------------------------------------------------
             // Validation methods
             //-----------------------------------------------------------------
-            _validateProperty: function(property, value){
+            _validateProperty: function(property, value) {
                 Validation.validate(property, value);
             },
 
@@ -3527,17 +3155,17 @@ Parser.prototype = function(){
             // Parsing methods
             //-----------------------------------------------------------------
 
-            parse: function(input){
+            parse: function(input) {
                 this._tokenStream = new TokenStream(input, Tokens);
                 this._stylesheet();
             },
 
-            parseStyleSheet: function(input){
+            parseStyleSheet: function(input) {
                 //just passthrough
                 return this.parse(input);
             },
 
-            parseMediaQuery: function(input){
+            parseMediaQuery: function(input) {
                 this._tokenStream = new TokenStream(input, Tokens);
                 var result = this._media_query();
 
@@ -3554,7 +3182,7 @@ Parser.prototype = function(){
              * @throws parserlib.util.SyntaxError If an unexpected token is found.
              * @method parserPropertyValue
              */
-            parsePropertyValue: function(input){
+            parsePropertyValue: function(input) {
 
                 this._tokenStream = new TokenStream(input, Tokens);
                 this._readWhitespace();
@@ -3578,7 +3206,7 @@ Parser.prototype = function(){
              * @return {Boolean} True if the parse completed successfully, false if not.
              * @method parseRule
              */
-            parseRule: function(input){
+            parseRule: function(input) {
                 this._tokenStream = new TokenStream(input, Tokens);
 
                 //skip any leading white space
@@ -3603,7 +3231,7 @@ Parser.prototype = function(){
              * @throws parserlib.util.SyntaxError If an unexpected token is found.
              * @method parseSelector
              */
-            parseSelector: function(input){
+            parseSelector: function(input) {
 
                 this._tokenStream = new TokenStream(input, Tokens);
 
@@ -3629,7 +3257,7 @@ Parser.prototype = function(){
              * @return {void}
              * @method parseStyleAttribute
              */
-            parseStyleAttribute: function(input){
+            parseStyleAttribute: function(input) {
                 input += "}"; // for error recovery in _readDeclarations()
                 this._tokenStream = new TokenStream(input, Tokens);
                 this._readDeclarations();
@@ -3637,8 +3265,8 @@ Parser.prototype = function(){
         };
 
     //copy over onto prototype
-    for (prop in additions){
-        if (additions.hasOwnProperty(prop)){
+    for (prop in additions) {
+        if (Object.prototype.hasOwnProperty.call(additions, prop)) {
             proto[prop] = additions[prop];
         }
     }
@@ -3654,102 +3282,84 @@ nth
   ;
 */
 
-/*global Validation, ValidationTypes, ValidationError*/
-var Properties = {
+},{"../util/EventTarget":23,"../util/SyntaxError":25,"../util/SyntaxUnit":26,"./Combinator":2,"./MediaFeature":4,"./MediaQuery":5,"./PropertyName":8,"./PropertyValue":9,"./PropertyValuePart":11,"./Selector":13,"./SelectorPart":14,"./SelectorSubPart":15,"./TokenStream":17,"./Tokens":18,"./Validation":19}],7:[function(require,module,exports){
+"use strict";
+
+/* exported Properties */
+
+var Properties = module.exports = {
+    __proto__: null,
 
     //A
     "align-items"                   : "flex-start | flex-end | center | baseline | stretch",
     "align-content"                 : "flex-start | flex-end | center | space-between | space-around | stretch",
     "align-self"                    : "auto | flex-start | flex-end | center | baseline | stretch",
+    "all"                           : "initial | inherit | unset",
     "-webkit-align-items"           : "flex-start | flex-end | center | baseline | stretch",
     "-webkit-align-content"         : "flex-start | flex-end | center | space-between | space-around | stretch",
     "-webkit-align-self"            : "auto | flex-start | flex-end | center | baseline | stretch",
     "alignment-adjust"              : "auto | baseline | before-edge | text-before-edge | middle | central | after-edge | text-after-edge | ideographic | alphabetic | hanging | mathematical | <percentage> | <length>",
-    "alignment-baseline"            : "auto | baseline | use-script | before-edge | text-before-edge | after-edge | text-after-edge | central | middle | ideographic | alphabetic | hanging | mathematical | inherit",
+    "alignment-baseline"            : "auto | baseline | use-script | before-edge | text-before-edge | after-edge | text-after-edge | central | middle | ideographic | alphabetic | hanging | mathematical",
     "animation"                     : 1,
-    "animation-delay"               : { multi: "<time>", comma: true },
-    "animation-direction"           : { multi: "normal | alternate", comma: true },
-    "animation-duration"            : { multi: "<time>", comma: true },
-    "animation-fill-mode"           : { multi: "none | forwards | backwards | both", comma: true },
-    "animation-iteration-count"     : { multi: "<number> | infinite", comma: true },
-    "animation-name"                : { multi: "none | <ident>", comma: true },
-    "animation-play-state"          : { multi: "running | paused", comma: true },
+    "animation-delay"               : "<time>#",
+    "animation-direction"           : "<single-animation-direction>#",
+    "animation-duration"            : "<time>#",
+    "animation-fill-mode"           : "[ none | forwards | backwards | both ]#",
+    "animation-iteration-count"     : "[ <number> | infinite ]#",
+    "animation-name"                : "[ none | <single-animation-name> ]#",
+    "animation-play-state"          : "[ running | paused ]#",
     "animation-timing-function"     : 1,
 
     //vendor prefixed
-    "-moz-animation-delay"               : { multi: "<time>", comma: true },
-    "-moz-animation-direction"           : { multi: "normal | alternate", comma: true },
-    "-moz-animation-duration"            : { multi: "<time>", comma: true },
-    "-moz-animation-iteration-count"     : { multi: "<number> | infinite", comma: true },
-    "-moz-animation-name"                : { multi: "none | <ident>", comma: true },
-    "-moz-animation-play-state"          : { multi: "running | paused", comma: true },
+    "-moz-animation-delay"               : "<time>#",
+    "-moz-animation-direction"           : "[ normal | alternate ]#",
+    "-moz-animation-duration"            : "<time>#",
+    "-moz-animation-iteration-count"     : "[ <number> | infinite ]#",
+    "-moz-animation-name"                : "[ none | <single-animation-name> ]#",
+    "-moz-animation-play-state"          : "[ running | paused ]#",
 
-    "-ms-animation-delay"               : { multi: "<time>", comma: true },
-    "-ms-animation-direction"           : { multi: "normal | alternate", comma: true },
-    "-ms-animation-duration"            : { multi: "<time>", comma: true },
-    "-ms-animation-iteration-count"     : { multi: "<number> | infinite", comma: true },
-    "-ms-animation-name"                : { multi: "none | <ident>", comma: true },
-    "-ms-animation-play-state"          : { multi: "running | paused", comma: true },
+    "-ms-animation-delay"               : "<time>#",
+    "-ms-animation-direction"           : "[ normal | alternate ]#",
+    "-ms-animation-duration"            : "<time>#",
+    "-ms-animation-iteration-count"     : "[ <number> | infinite ]#",
+    "-ms-animation-name"                : "[ none | <single-animation-name> ]#",
+    "-ms-animation-play-state"          : "[ running | paused ]#",
 
-    "-webkit-animation-delay"               : { multi: "<time>", comma: true },
-    "-webkit-animation-direction"           : { multi: "normal | alternate", comma: true },
-    "-webkit-animation-duration"            : { multi: "<time>", comma: true },
-    "-webkit-animation-fill-mode"           : { multi: "none | forwards | backwards | both", comma: true },
-    "-webkit-animation-iteration-count"     : { multi: "<number> | infinite", comma: true },
-    "-webkit-animation-name"                : { multi: "none | <ident>", comma: true },
-    "-webkit-animation-play-state"          : { multi: "running | paused", comma: true },
+    "-webkit-animation-delay"               : "<time>#",
+    "-webkit-animation-direction"           : "[ normal | alternate ]#",
+    "-webkit-animation-duration"            : "<time>#",
+    "-webkit-animation-fill-mode"           : "[ none | forwards | backwards | both ]#",
+    "-webkit-animation-iteration-count"     : "[ <number> | infinite ]#",
+    "-webkit-animation-name"                : "[ none | <single-animation-name> ]#",
+    "-webkit-animation-play-state"          : "[ running | paused ]#",
 
-    "-o-animation-delay"               : { multi: "<time>", comma: true },
-    "-o-animation-direction"           : { multi: "normal | alternate", comma: true },
-    "-o-animation-duration"            : { multi: "<time>", comma: true },
-    "-o-animation-iteration-count"     : { multi: "<number> | infinite", comma: true },
-    "-o-animation-name"                : { multi: "none | <ident>", comma: true },
-    "-o-animation-play-state"          : { multi: "running | paused", comma: true },
+    "-o-animation-delay"               : "<time>#",
+    "-o-animation-direction"           : "[ normal | alternate ]#",
+    "-o-animation-duration"            : "<time>#",
+    "-o-animation-iteration-count"     : "[ <number> | infinite ]#",
+    "-o-animation-name"                : "[ none | <single-animation-name> ]#",
+    "-o-animation-play-state"          : "[ running | paused ]#",
 
-    "appearance"                    : "icon | window | desktop | workspace | document | tooltip | dialog | button | push-button | hyperlink | radio-button | checkbox | menu-item | tab | menu | menubar | pull-down-menu | pop-up-menu | list-menu | radio-group | checkbox-group | outline-tree | range | field | combo-box | signature | password | normal | none | inherit",
-    "azimuth"                       : function (expression) {
-        var simple      = "<angle> | leftwards | rightwards | inherit",
-            direction   = "left-side | far-left | left | center-left | center | center-right | right | far-right | right-side",
-            behind      = false,
-            valid       = false,
-            part;
+    "appearance"                    : "none | auto",
+    "-moz-appearance"               : "none | button | button-arrow-down | button-arrow-next | button-arrow-previous | button-arrow-up | button-bevel | button-focus | caret | checkbox | checkbox-container | checkbox-label | checkmenuitem | dualbutton | groupbox | listbox | listitem | menuarrow | menubar | menucheckbox | menuimage | menuitem | menuitemtext | menulist | menulist-button | menulist-text | menulist-textfield | menupopup | menuradio | menuseparator | meterbar | meterchunk | progressbar | progressbar-vertical | progresschunk | progresschunk-vertical | radio | radio-container | radio-label | radiomenuitem | range | range-thumb | resizer | resizerpanel | scale-horizontal | scalethumbend | scalethumb-horizontal | scalethumbstart | scalethumbtick | scalethumb-vertical | scale-vertical | scrollbarbutton-down | scrollbarbutton-left | scrollbarbutton-right | scrollbarbutton-up | scrollbarthumb-horizontal | scrollbarthumb-vertical | scrollbartrack-horizontal | scrollbartrack-vertical | searchfield | separator | sheet | spinner | spinner-downbutton | spinner-textfield | spinner-upbutton | splitter | statusbar | statusbarpanel | tab | tabpanel | tabpanels | tab-scroll-arrow-back | tab-scroll-arrow-forward | textfield | textfield-multiline | toolbar | toolbarbutton | toolbarbutton-dropdown | toolbargripper | toolbox | tooltip | treeheader | treeheadercell | treeheadersortarrow | treeitem | treeline | treetwisty | treetwistyopen | treeview | -moz-mac-unified-toolbar | -moz-win-borderless-glass | -moz-win-browsertabbar-toolbox | -moz-win-communicationstext | -moz-win-communications-toolbox | -moz-win-exclude-glass | -moz-win-glass | -moz-win-mediatext | -moz-win-media-toolbox | -moz-window-button-box | -moz-window-button-box-maximized | -moz-window-button-close | -moz-window-button-maximize | -moz-window-button-minimize | -moz-window-button-restore | -moz-window-frame-bottom | -moz-window-frame-left | -moz-window-frame-right | -moz-window-titlebar | -moz-window-titlebar-maximized",
+    "-ms-appearance"                : "none | icon | window | desktop | workspace | document | tooltip | dialog | button | push-button | hyperlink | radio | radio-button | checkbox | menu-item | tab | menu | menubar | pull-down-menu | pop-up-menu | list-menu | radio-group | checkbox-group | outline-tree | range | field | combo-box | signature | password | normal",
+    "-webkit-appearance"            : "none | button | button-bevel | caps-lock-indicator | caret | checkbox | default-button | listbox	| listitem | media-fullscreen-button | media-mute-button | media-play-button | media-seek-back-button	| media-seek-forward-button	| media-slider | media-sliderthumb | menulist	| menulist-button	| menulist-text	| menulist-textfield | push-button	| radio	| searchfield	| searchfield-cancel-button	| searchfield-decoration | searchfield-results-button | searchfield-results-decoration | slider-horizontal | slider-vertical | sliderthumb-horizontal | sliderthumb-vertical	| square-button	| textarea	| textfield	| scrollbarbutton-down | scrollbarbutton-left | scrollbarbutton-right | scrollbarbutton-up | scrollbargripper-horizontal | scrollbargripper-vertical | scrollbarthumb-horizontal | scrollbarthumb-vertical | scrollbartrack-horizontal | scrollbartrack-vertical",
+    "-o-appearance"                 : "none | window | desktop | workspace | document | tooltip | dialog | button | push-button | hyperlink | radio | radio-button | checkbox | menu-item | tab | menu | menubar | pull-down-menu | pop-up-menu | list-menu | radio-group | checkbox-group | outline-tree | range | field | combo-box | signature | password | normal",
 
-        if (!ValidationTypes.isAny(expression, simple)) {
-            if (ValidationTypes.isAny(expression, "behind")) {
-                behind = true;
-                valid = true;
-            }
-
-            if (ValidationTypes.isAny(expression, direction)) {
-                valid = true;
-                if (!behind) {
-                    ValidationTypes.isAny(expression, "behind");
-                }
-            }
-        }
-
-        if (expression.hasNext()) {
-            part = expression.next();
-            if (valid) {
-                throw new ValidationError("Expected end of value but found '" + part + "'.", part.line, part.col);
-            } else {
-                throw new ValidationError("Expected (<'azimuth'>) but found '" + part + "'.", part.line, part.col);
-            }
-        }
-    },
+    "azimuth"                       : "<azimuth>",
 
     //B
     "backface-visibility"           : "visible | hidden",
     "background"                    : 1,
-    "background-attachment"         : { multi: "<attachment>", comma: true },
-    "background-clip"               : { multi: "<box>", comma: true },
-    "background-color"              : "<color> | inherit",
-    "background-image"              : { multi: "<bg-image>", comma: true },
-    "background-origin"             : { multi: "<box>", comma: true },
-    "background-position"           : { multi: "<bg-position>", comma: true },
-    "background-repeat"             : { multi: "<repeat-style>" },
-    "background-size"               : { multi: "<bg-size>", comma: true },
-    "baseline-shift"                : "baseline | sub | super | <percentage> | <length> | inherit",
+    "background-attachment"         : "<attachment>#",
+    "background-clip"               : "<box>#",
+    "background-color"              : "<color>",
+    "background-image"              : "<bg-image>#",
+    "background-origin"             : "<box>#",
+    "background-position"           : "<bg-position>",
+    "background-repeat"             : "<repeat-style>#",
+    "background-size"               : "<bg-size>#",
+    "baseline-shift"                : "baseline | sub | super | <percentage> | <length>",
     "behavior"                      : 1,
     "binding"                       : 1,
     "bleed"                         : "<length>",
@@ -3759,158 +3369,77 @@ var Properties = {
     "bookmark-target"               : "none | <uri> | <attr>",
     "border"                        : "<border-width> || <border-style> || <color>",
     "border-bottom"                 : "<border-width> || <border-style> || <color>",
-    "border-bottom-color"           : "<color> | inherit",
+    "border-bottom-color"           : "<color>",
     "border-bottom-left-radius"     :  "<x-one-radius>",
     "border-bottom-right-radius"    :  "<x-one-radius>",
     "border-bottom-style"           : "<border-style>",
     "border-bottom-width"           : "<border-width>",
-    "border-collapse"               : "collapse | separate | inherit",
-    "border-color"                  : { multi: "<color> | inherit", max: 4 },
+    "border-collapse"               : "collapse | separate",
+    "border-color"                  : "<color>{1,4}",
     "border-image"                  : 1,
-    "border-image-outset"           : { multi: "<length> | <number>", max: 4 },
-    "border-image-repeat"           : { multi: "stretch | repeat | round", max: 2 },
-    "border-image-slice"            : function(expression) {
-
-        var valid   = false,
-            numeric = "<number> | <percentage>",
-            fill    = false,
-            count   = 0,
-            max     = 4,
-            part;
-
-        if (ValidationTypes.isAny(expression, "fill")) {
-            fill = true;
-            valid = true;
-        }
-
-        while (expression.hasNext() && count < max) {
-            valid = ValidationTypes.isAny(expression, numeric);
-            if (!valid) {
-                break;
-            }
-            count++;
-        }
-
-
-        if (!fill) {
-            ValidationTypes.isAny(expression, "fill");
-        } else {
-            valid = true;
-        }
-
-        if (expression.hasNext()) {
-            part = expression.next();
-            if (valid) {
-                throw new ValidationError("Expected end of value but found '" + part + "'.", part.line, part.col);
-            } else {
-                throw new ValidationError("Expected ([<number> | <percentage>]{1,4} && fill?) but found '" + part + "'.", part.line, part.col);
-            }
-        }
-    },
+    "border-image-outset"           : "[ <length> | <number> ]{1,4}",
+    "border-image-repeat"           : "[ stretch | repeat | round ]{1,2}",
+    "border-image-slice"            : "<border-image-slice>",
     "border-image-source"           : "<image> | none",
-    "border-image-width"            : { multi: "<length> | <percentage> | <number> | auto", max: 4 },
+    "border-image-width"            : "[ <length> | <percentage> | <number> | auto ]{1,4}",
     "border-left"                   : "<border-width> || <border-style> || <color>",
-    "border-left-color"             : "<color> | inherit",
+    "border-left-color"             : "<color>",
     "border-left-style"             : "<border-style>",
     "border-left-width"             : "<border-width>",
-    "border-radius"                 : function(expression) {
-
-        var valid   = false,
-            simple = "<length> | <percentage> | inherit",
-            slash   = false,
-            fill    = false,
-            count   = 0,
-            max     = 8,
-            part;
-
-        while (expression.hasNext() && count < max) {
-            valid = ValidationTypes.isAny(expression, simple);
-            if (!valid) {
-
-                if (expression.peek() == "/" && count > 0 && !slash) {
-                    slash = true;
-                    max = count + 5;
-                    expression.next();
-                } else {
-                    break;
-                }
-            }
-            count++;
-        }
-
-        if (expression.hasNext()) {
-            part = expression.next();
-            if (valid) {
-                throw new ValidationError("Expected end of value but found '" + part + "'.", part.line, part.col);
-            } else {
-                throw new ValidationError("Expected (<'border-radius'>) but found '" + part + "'.", part.line, part.col);
-            }
-        }
-    },
+    "border-radius"                 : "<border-radius>",
     "border-right"                  : "<border-width> || <border-style> || <color>",
-    "border-right-color"            : "<color> | inherit",
+    "border-right-color"            : "<color>",
     "border-right-style"            : "<border-style>",
     "border-right-width"            : "<border-width>",
-    "border-spacing"                : { multi: "<length> | inherit", max: 2 },
-    "border-style"                  : { multi: "<border-style>", max: 4 },
+    "border-spacing"                : "<length>{1,2}",
+    "border-style"                  : "<border-style>{1,4}",
     "border-top"                    : "<border-width> || <border-style> || <color>",
-    "border-top-color"              : "<color> | inherit",
+    "border-top-color"              : "<color>",
     "border-top-left-radius"        : "<x-one-radius>",
     "border-top-right-radius"       : "<x-one-radius>",
     "border-top-style"              : "<border-style>",
     "border-top-width"              : "<border-width>",
-    "border-width"                  : { multi: "<border-width>", max: 4 },
-    "bottom"                        : "<margin-width> | inherit",
+    "border-width"                  : "<border-width>{1,4}",
+    "bottom"                        : "<margin-width>",
     "-moz-box-align"                : "start | end | center | baseline | stretch",
-    "-moz-box-decoration-break"     : "slice |clone",
-    "-moz-box-direction"            : "normal | reverse | inherit",
+    "-moz-box-decoration-break"     : "slice | clone",
+    "-moz-box-direction"            : "normal | reverse",
     "-moz-box-flex"                 : "<number>",
     "-moz-box-flex-group"           : "<integer>",
     "-moz-box-lines"                : "single | multiple",
     "-moz-box-ordinal-group"        : "<integer>",
-    "-moz-box-orient"               : "horizontal | vertical | inline-axis | block-axis | inherit",
+    "-moz-box-orient"               : "horizontal | vertical | inline-axis | block-axis",
     "-moz-box-pack"                 : "start | end | center | justify",
     "-o-box-decoration-break"       : "slice | clone",
     "-webkit-box-align"             : "start | end | center | baseline | stretch",
-    "-webkit-box-decoration-break"  : "slice |clone",
-    "-webkit-box-direction"         : "normal | reverse | inherit",
+    "-webkit-box-decoration-break"  : "slice | clone",
+    "-webkit-box-direction"         : "normal | reverse",
     "-webkit-box-flex"              : "<number>",
     "-webkit-box-flex-group"        : "<integer>",
     "-webkit-box-lines"             : "single | multiple",
     "-webkit-box-ordinal-group"     : "<integer>",
-    "-webkit-box-orient"            : "horizontal | vertical | inline-axis | block-axis | inherit",
+    "-webkit-box-orient"            : "horizontal | vertical | inline-axis | block-axis",
     "-webkit-box-pack"              : "start | end | center | justify",
     "box-decoration-break"          : "slice | clone",
-    "box-shadow"                    : function (expression) {
-        var result      = false,
-            part;
-
-        if (!ValidationTypes.isAny(expression, "none")) {
-            Validation.multiProperty("<shadow>", expression, true, Infinity);
-        } else {
-            if (expression.hasNext()) {
-                part = expression.next();
-                throw new ValidationError("Expected end of value but found '" + part + "'.", part.line, part.col);
-            }
-        }
-    },
-    "box-sizing"                    : "content-box | border-box | inherit",
+    "box-shadow"                    : "<box-shadow>",
+    "box-sizing"                    : "content-box | border-box",
     "break-after"                   : "auto | always | avoid | left | right | page | column | avoid-page | avoid-column",
     "break-before"                  : "auto | always | avoid | left | right | page | column | avoid-page | avoid-column",
     "break-inside"                  : "auto | avoid | avoid-page | avoid-column",
 
     //C
-    "caption-side"                  : "top | bottom | inherit",
-    "clear"                         : "none | right | left | both | inherit",
-    "clip"                          : 1,
-    "clip-path"                     : 1,
-    "clip-rule"                     : "nonzero | evenodd | inherit",
-    "color"                         : "<color> | inherit",
-    "color-interpolation"           : "auto | sRGB | linearRGB | inherit",
-    "color-interpolation-filters"   : "auto | sRGB | linearRGB | inherit",
+    "caption-side"                  : "top | bottom",
+    "clear"                         : "none | right | left | both",
+    "clip"                          : "<shape> | auto",
+    "-webkit-clip-path"             : "<clip-source> | <clip-path> | none",
+    "clip-path"                     : "<clip-source> | <clip-path> | none",
+    "clip-rule"                     : "nonzero | evenodd",
+    "color"                         : "<color>",
+    "color-interpolation"           : "auto | sRGB | linearRGB",
+    "color-interpolation-filters"   : "auto | sRGB | linearRGB",
     "color-profile"                 : 1,
-    "color-rendering"               : "auto | optimizeSpeed | optimizeQuality | inherit",
-    "column-count"                  : "<integer> | auto",                      //http://www.w3.org/TR/css3-multicol/
+    "color-rendering"               : "auto | optimizeSpeed | optimizeQuality",
+    "column-count"                  : "<integer> | auto",                      //https://www.w3.org/TR/css3-multicol/
     "column-fill"                   : "auto | balance",
     "column-gap"                    : "<length> | normal",
     "column-rule"                   : "<border-width> || <border-style> || <color>",
@@ -3924,32 +3453,32 @@ var Properties = {
     "counter-increment"             : 1,
     "counter-reset"                 : 1,
     "crop"                          : "<shape> | auto",
-    "cue"                           : "cue-after | cue-before | inherit",
+    "cue"                           : "cue-after | cue-before",
     "cue-after"                     : 1,
     "cue-before"                    : 1,
     "cursor"                        : 1,
 
     //D
-    "direction"                     : "ltr | rtl | inherit",
-    "display"                       : "inline | block | list-item | inline-block | table | inline-table | table-row-group | table-header-group | table-footer-group | table-row | table-column-group | table-column | table-cell | table-caption | grid | inline-grid | run-in | ruby | ruby-base | ruby-text | ruby-base-container | ruby-text-container | contents | none | inherit | -moz-box | -moz-inline-block | -moz-inline-box | -moz-inline-grid | -moz-inline-stack | -moz-inline-table | -moz-grid | -moz-grid-group | -moz-grid-line | -moz-groupbox | -moz-deck | -moz-popup | -moz-stack | -moz-marker | -webkit-box | -webkit-inline-box | -ms-flexbox | -ms-inline-flexbox | flex | -webkit-flex | inline-flex | -webkit-inline-flex",
-    "dominant-baseline"             : "auto | use-script | no-change | reset-size | ideographic | alphabetic | hanging | mathematical | central | middle | text-after-edge | text-before-edge | inherit",
+    "direction"                     : "ltr | rtl",
+    "display"                       : "inline | block | list-item | inline-block | table | inline-table | table-row-group | table-header-group | table-footer-group | table-row | table-column-group | table-column | table-cell | table-caption | grid | inline-grid | run-in | ruby | ruby-base | ruby-text | ruby-base-container | ruby-text-container | contents | none | -moz-box | -moz-inline-block | -moz-inline-box | -moz-inline-grid | -moz-inline-stack | -moz-inline-table | -moz-grid | -moz-grid-group | -moz-grid-line | -moz-groupbox | -moz-deck | -moz-popup | -moz-stack | -moz-marker | -webkit-box | -webkit-inline-box | -ms-flexbox | -ms-inline-flexbox | flex | -webkit-flex | inline-flex | -webkit-inline-flex",
+    "dominant-baseline"             : "auto | use-script | no-change | reset-size | ideographic | alphabetic | hanging | mathematical | central | middle | text-after-edge | text-before-edge",
     "drop-initial-after-adjust"     : "central | middle | after-edge | text-after-edge | ideographic | alphabetic | mathematical | <percentage> | <length>",
     "drop-initial-after-align"      : "baseline | use-script | before-edge | text-before-edge | after-edge | text-after-edge | central | middle | ideographic | alphabetic | hanging | mathematical",
     "drop-initial-before-adjust"    : "before-edge | text-before-edge | central | middle | hanging | mathematical | <percentage> | <length>",
     "drop-initial-before-align"     : "caps-height | baseline | use-script | before-edge | text-before-edge | after-edge | text-after-edge | central | middle | ideographic | alphabetic | hanging | mathematical",
     "drop-initial-size"             : "auto | line | <length> | <percentage>",
-    "drop-initial-value"            : "initial | <integer>",
+    "drop-initial-value"            : "<integer>",
 
     //E
-    "elevation"                     : "<angle> | below | level | above | higher | lower | inherit",
-    "empty-cells"                   : "show | hide | inherit",
+    "elevation"                     : "<angle> | below | level | above | higher | lower",
+    "empty-cells"                   : "show | hide",
     "enable-background"             : 1,
 
     //F
-    "fill"                          : 1,
-    "fill-opacity"                  : "<number> | inherit",
-    "fill-rule"                     : "nonzero | evenodd | inherit",
-    "filter"                        : 1,
+    "fill"                          : "<paint>",
+    "fill-opacity"                  : "<opacity-value>",
+    "fill-rule"                     : "nonzero | evenodd",
+    "filter"                        : "<filter-function-list> | none",
     "fit"                           : "fill | hidden | meet | slice",
     "fit-position"                  : 1,
     "flex"                          : "<flex>",
@@ -3968,30 +3497,34 @@ var Properties = {
     "-webkit-flex-wrap"             : "nowrap | wrap | wrap-reverse",
     "-ms-flex"                      : "<flex>",
     "-ms-flex-align"                : "start | end | center | stretch | baseline",
-    "-ms-flex-direction"            : "row | row-reverse | column | column-reverse | inherit",
+    "-ms-flex-direction"            : "row | row-reverse | column | column-reverse",
     "-ms-flex-order"                : "<number>",
     "-ms-flex-pack"                 : "start | end | center | justify",
     "-ms-flex-wrap"                 : "nowrap | wrap | wrap-reverse",
-    "float"                         : "left | right | none | inherit",
+    "float"                         : "left | right | none",
     "float-offset"                  : 1,
     "flood-color"                   : 1,
-    "flood-opacity"                 : "<number> | inherit",
-    "font"                          : 1,
-    "font-family"                   : 1,
-    "font-feature-settings"         : "<feature-tag-value> | normal | inherit",
-    "font-kerning"                  : "auto | normal | none | initial | inherit | unset",
-    "font-size"                     : "<absolute-size> | <relative-size> | <length> | <percentage> | inherit",
-    "font-size-adjust"              : "<number> | none | inherit",
-    "font-stretch"                  : "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded | inherit",
-    "font-style"                    : "normal | italic | oblique | inherit",
-    "font-variant"                  : "normal | small-caps | inherit",
-    "font-variant-caps"             : "normal | small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps",
-    "font-variant-position"         : "normal | sub | super | inherit | initial | unset",
-    "font-weight"                   : "normal | bold | bolder | lighter | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | inherit",
+    "flood-opacity"                 : "<opacity-value>",
+    "font"                          : "<font-shorthand> | caption | icon | menu | message-box | small-caption | status-bar",
+    "font-family"                   : "<font-family>",
+    "font-feature-settings"         : "<feature-tag-value> | normal",
+    "font-kerning"                  : "auto | normal | none",
+    "font-size"                     : "<font-size>",
+    "font-size-adjust"              : "<number> | none",
+    "font-stretch"                  : "<font-stretch>",
+    "font-style"                    : "<font-style>",
+    "font-variant"                  : "<font-variant> | normal | none",
+    "font-variant-alternates"       : "<font-variant-alternates> | normal",
+    "font-variant-caps"             : "<font-variant-caps> | normal",
+    "font-variant-east-asian"       : "<font-variant-east-asian> | normal",
+    "font-variant-ligatures"        : "<font-variant-ligatures> | normal | none",
+    "font-variant-numeric"          : "<font-variant-numeric> | normal",
+    "font-variant-position"         : "normal | sub | super",
+    "font-weight"                   : "<font-weight>",
 
     //G
-    "glyph-orientation-horizontal"  : "<angle> | inherit",
-    "glyph-orientation-vertical"    : "auto | <angle> | inherit",
+    "glyph-orientation-horizontal"  : "<glyph-angle>",
+    "glyph-orientation-vertical"    : "auto | <glyph-angle>",
     "grid"                          : 1,
     "grid-area"                     : 1,
     "grid-auto-columns"             : 1,
@@ -4022,7 +3555,7 @@ var Properties = {
 
     //H
     "hanging-punctuation"           : 1,
-    "height"                        : "<margin-width> | <content-sizing> | inherit",
+    "height"                        : "<margin-width> | <content-sizing>",
     "hyphenate-after"               : "<integer> | auto",
     "hyphenate-before"              : "<integer> | auto",
     "hyphenate-character"           : "<string> | auto",
@@ -4033,39 +3566,38 @@ var Properties = {
     //I
     "icon"                          : 1,
     "image-orientation"             : "angle | auto",
-    "image-rendering"               : "auto | optimizeSpeed | optimizeQuality | inherit",
+    "image-rendering"               : "auto | optimizeSpeed | optimizeQuality",
     "image-resolution"              : 1,
-    "ime-mode"                      : "auto | normal | active | inactive | disabled | inherit",
-    "inline-box-align"              : "initial | last | <integer>",
+    "ime-mode"                      : "auto | normal | active | inactive | disabled",
+    "inline-box-align"              : "last | <integer>",
 
     //J
     "justify-content"               : "flex-start | flex-end | center | space-between | space-around",
     "-webkit-justify-content"       : "flex-start | flex-end | center | space-between | space-around",
 
     //K
-    "kerning"                       : "auto | <length> | inherit",
+    "kerning"                       : "auto | <length>",
 
     //L
-    "left"                          : "<margin-width> | inherit",
-    "letter-spacing"                : "<length> | normal | inherit",
-    "lighting-color"                : 1,
-    "line-height"                   : "<number> | <length> | <percentage> | normal | inherit",
+    "left"                          : "<margin-width>",
+    "letter-spacing"                : "<length> | normal",
+    "line-height"                   : "<line-height>",
     "line-break"                    : "auto | loose | normal | strict",
     "line-stacking"                 : 1,
     "line-stacking-ruby"            : "exclude-ruby | include-ruby",
     "line-stacking-shift"           : "consider-shifts | disregard-shifts",
     "line-stacking-strategy"        : "inline-line-height | block-line-height | max-height | grid-height",
     "list-style"                    : 1,
-    "list-style-image"              : "<uri> | none | inherit",
-    "list-style-position"           : "inside | outside | inherit",
-    "list-style-type"               : "disc | circle | square | decimal | decimal-leading-zero | lower-roman | upper-roman | lower-greek | lower-latin | upper-latin | armenian | georgian | lower-alpha | upper-alpha | none | inherit",
+    "list-style-image"              : "<uri> | none",
+    "list-style-position"           : "inside | outside",
+    "list-style-type"               : "disc | circle | square | decimal | decimal-leading-zero | lower-roman | upper-roman | lower-greek | lower-latin | upper-latin | armenian | georgian | lower-alpha | upper-alpha | none",
 
     //M
-    "margin"                        : { multi: "<margin-width> | inherit", max: 4 },
-    "margin-bottom"                 : "<margin-width> | inherit",
-    "margin-left"                   : "<margin-width> | inherit",
-    "margin-right"                  : "<margin-width> | inherit",
-    "margin-top"                    : "<margin-width> | inherit",
+    "margin"                        : "<margin-width>{1,4}",
+    "margin-bottom"                 : "<margin-width>",
+    "margin-left"                   : "<margin-width>",
+    "margin-right"                  : "<margin-width>",
+    "margin-top"                    : "<margin-width>",
     "mark"                          : 1,
     "mark-after"                    : 1,
     "mark-before"                   : 1,
@@ -4079,10 +3611,10 @@ var Properties = {
     "marquee-speed"                 : 1,
     "marquee-style"                 : 1,
     "mask"                          : 1,
-    "max-height"                    : "<length> | <percentage> | <content-sizing> | none | inherit",
-    "max-width"                     : "<length> | <percentage> | <content-sizing> | none | inherit",
-    "min-height"                    : "<length> | <percentage> | <content-sizing> | contain-floats | -moz-contain-floats | -webkit-contain-floats | inherit",
-    "min-width"                     : "<length> | <percentage> | <content-sizing> | contain-floats | -moz-contain-floats | -webkit-contain-floats | inherit",
+    "max-height"                    : "<length> | <percentage> | <content-sizing> | none",
+    "max-width"                     : "<length> | <percentage> | <content-sizing> | none",
+    "min-height"                    : "<length> | <percentage> | <content-sizing> | contain-floats | -moz-contain-floats | -webkit-contain-floats",
+    "min-width"                     : "<length> | <percentage> | <content-sizing> | contain-floats | -moz-contain-floats | -webkit-contain-floats",
     "move-to"                       : 1,
 
     //N
@@ -4094,32 +3626,32 @@ var Properties = {
 
     //O
     "object-fit"                    : "fill | contain | cover | none | scale-down",
-    "object-position"               : "<bg-position>",
-    "opacity"                       : "<number> | inherit",
+    "object-position"               : "<position>",
+    "opacity"                       : "<opacity-value>",
     "order"                         : "<integer>",
     "-webkit-order"                 : "<integer>",
-    "orphans"                       : "<integer> | inherit",
+    "orphans"                       : "<integer>",
     "outline"                       : 1,
-    "outline-color"                 : "<color> | invert | inherit",
+    "outline-color"                 : "<color> | invert",
     "outline-offset"                : 1,
-    "outline-style"                 : "<border-style> | inherit",
-    "outline-width"                 : "<border-width> | inherit",
-    "overflow"                      : "visible | hidden | scroll | auto | inherit",
+    "outline-style"                 : "<border-style>",
+    "outline-width"                 : "<border-width>",
+    "overflow"                      : "visible | hidden | scroll | auto",
     "overflow-style"                : 1,
     "overflow-wrap"                 : "normal | break-word",
     "overflow-x"                    : 1,
     "overflow-y"                    : 1,
 
     //P
-    "padding"                       : { multi: "<padding-width> | inherit", max: 4 },
-    "padding-bottom"                : "<padding-width> | inherit",
-    "padding-left"                  : "<padding-width> | inherit",
-    "padding-right"                 : "<padding-width> | inherit",
-    "padding-top"                   : "<padding-width> | inherit",
+    "padding"                       : "<padding-width>{1,4}",
+    "padding-bottom"                : "<padding-width>",
+    "padding-left"                  : "<padding-width>",
+    "padding-right"                 : "<padding-width>",
+    "padding-top"                   : "<padding-width>",
     "page"                          : 1,
-    "page-break-after"              : "auto | always | avoid | left | right | inherit",
-    "page-break-before"             : "auto | always | avoid | left | right | inherit",
-    "page-break-inside"             : "auto | avoid | inherit",
+    "page-break-after"              : "auto | always | avoid | left | right",
+    "page-break-before"             : "auto | always | avoid | left | right",
+    "page-break-inside"             : "auto | avoid",
     "page-policy"                   : 1,
     "pause"                         : 1,
     "pause-after"                   : 1,
@@ -4130,8 +3662,8 @@ var Properties = {
     "pitch"                         : 1,
     "pitch-range"                   : 1,
     "play-during"                   : 1,
-    "pointer-events"                : "auto | none | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | inherit",
-    "position"                      : "static | relative | absolute | fixed | inherit",
+    "pointer-events"                : "auto | none | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all",
+    "position"                      : "static | relative | absolute | fixed",
     "presentation-level"            : 1,
     "punctuation-trim"              : 1,
 
@@ -4145,7 +3677,7 @@ var Properties = {
     "rest-after"                    : 1,
     "rest-before"                   : 1,
     "richness"                      : 1,
-    "right"                         : "<margin-width> | inherit",
+    "right"                         : "<margin-width>",
     "rotation"                      : 1,
     "rotation-point"                : 1,
     "ruby-align"                    : 1,
@@ -4154,51 +3686,53 @@ var Properties = {
     "ruby-span"                     : 1,
 
     //S
-    "shape-rendering"               : "auto | optimizeSpeed | crispEdges | geometricPrecision | inherit",
+    "shape-rendering"               : "auto | optimizeSpeed | crispEdges | geometricPrecision",
     "size"                          : 1,
-    "speak"                         : "normal | none | spell-out | inherit",
-    "speak-header"                  : "once | always | inherit",
-    "speak-numeral"                 : "digits | continuous | inherit",
-    "speak-punctuation"             : "code | none | inherit",
+    "speak"                         : "normal | none | spell-out",
+    "speak-header"                  : "once | always",
+    "speak-numeral"                 : "digits | continuous",
+    "speak-punctuation"             : "code | none",
     "speech-rate"                   : 1,
     "src"                           : 1,
     "stop-color"                    : 1,
-    "stop-opacity"                  : "<number> | inherit",
+    "stop-opacity"                  : "<opacity-value>",
     "stress"                        : 1,
     "string-set"                    : 1,
-    "stroke"                        : 1,
-    "stroke-dasharray"              : 1,
-    "stroke-dashoffset"             : "<percentage> | <length> | inherit",
-    "stroke-linecap"                : "butt | round | square | inherit",
-    "stroke-linejoin"               : "miter | round | bevel | inherit",
-    "stroke-miterlimit"             : "<number> | inherit",
-    "stroke-opacity"                : "<number> | inherit",
-    "stroke-width"                  : "<percentage> | <length> | inherit",
+    "stroke"                        : "<paint>",
+    "stroke-dasharray"              : "none | <dasharray>",
+    "stroke-dashoffset"             : "<percentage> | <length>",
+    "stroke-linecap"                : "butt | round | square",
+    "stroke-linejoin"               : "miter | round | bevel",
+    "stroke-miterlimit"             : "<miterlimit>",
+    "stroke-opacity"                : "<opacity-value>",
+    "stroke-width"                  : "<percentage> | <length>",
 
-    //T
-    "table-layout"                  : "auto | fixed | inherit",
+    "table-layout"                  : "auto | fixed",
     "tab-size"                      : "<integer> | <length>",
     "target"                        : 1,
     "target-name"                   : 1,
     "target-new"                    : 1,
     "target-position"               : 1,
-    "text-align"                    : "left | right | center | justify | match-parent | start | end | inherit" ,
+    "text-align"                    : "left | right | center | justify | match-parent | start | end",
     "text-align-last"               : 1,
-    "text-anchor"                   : "start | middle | end | inherit",
-    "text-decoration"               : 1,
+    "text-anchor"                   : "start | middle | end",
+    "text-decoration"               : "<text-decoration-line> || <text-decoration-style> || <text-decoration-color>",
+    "text-decoration-color"         : "<text-decoration-color>",
+    "text-decoration-line"          : "<text-decoration-line>",
+    "text-decoration-style"         : "<text-decoration-style>",
     "text-emphasis"                 : 1,
     "text-height"                   : 1,
-    "text-indent"                   : "<length> | <percentage> | inherit",
+    "text-indent"                   : "<length> | <percentage>",
     "text-justify"                  : "auto | none | inter-word | inter-ideograph | inter-cluster | distribute | kashida",
     "text-outline"                  : 1,
     "text-overflow"                 : 1,
-    "text-rendering"                : "auto | optimizeSpeed | optimizeLegibility | geometricPrecision | inherit",
+    "text-rendering"                : "auto | optimizeSpeed | optimizeLegibility | geometricPrecision",
     "text-shadow"                   : 1,
-    "text-transform"                : "capitalize | uppercase | lowercase | none | inherit",
+    "text-transform"                : "capitalize | uppercase | lowercase | none",
     "text-wrap"                     : "normal | none | avoid",
-    "top"                           : "<margin-width> | inherit",
-    "-ms-touch-action"              : "auto | none | pan-x | pan-y",
-    "touch-action"                  : "auto | none | pan-x | pan-y",
+    "top"                           : "<margin-width>",
+    "-ms-touch-action"              : "auto | none | pan-x | pan-y | pan-left | pan-right | pan-up | pan-down | manipulation",
+    "touch-action"                  : "auto | none | pan-x | pan-y | pan-left | pan-right | pan-up | pan-down | manipulation",
     "transform"                     : 1,
     "transform-origin"              : 1,
     "transform-style"               : 1,
@@ -4209,13 +3743,13 @@ var Properties = {
     "transition-timing-function"    : 1,
 
     //U
-    "unicode-bidi"                  : "normal | embed | isolate | bidi-override | isolate-override | plaintext | inherit",
-    "user-modify"                   : "read-only | read-write | write-only | inherit",
-    "user-select"                   : "none | text | toggle | element | elements | all | inherit",
+    "unicode-bidi"                  : "normal | embed | isolate | bidi-override | isolate-override | plaintext",
+    "user-modify"                   : "read-only | read-write | write-only",
+    "user-select"                   : "none | text | toggle | element | elements | all",
 
     //V
-    "vertical-align"                : "auto | use-script | baseline | sub | super | top | text-top | central | middle | bottom | text-bottom | <percentage> | <length> | inherit",
-    "visibility"                    : "visible | hidden | collapse | inherit",
+    "vertical-align"                : "auto | use-script | baseline | sub | super | top | text-top | central | middle | bottom | text-bottom | <percentage> | <length>",
+    "visibility"                    : "visible | hidden | collapse",
     "voice-balance"                 : 1,
     "voice-duration"                : 1,
     "voice-family"                  : 1,
@@ -4227,22 +3761,30 @@ var Properties = {
     "volume"                        : 1,
 
     //W
-    "white-space"                   : "normal | pre | nowrap | pre-wrap | pre-line | inherit | -pre-wrap | -o-pre-wrap | -moz-pre-wrap | -hp-pre-wrap", //http://perishablepress.com/wrapping-content/
+    "white-space"                   : "normal | pre | nowrap | pre-wrap | pre-line | -pre-wrap | -o-pre-wrap | -moz-pre-wrap | -hp-pre-wrap",   // https://perishablepress.com/wrapping-content/
     "white-space-collapse"          : 1,
-    "widows"                        : "<integer> | inherit",
-    "width"                         : "<length> | <percentage> | <content-sizing> | auto | inherit",
-    "will-change"                   : { multi: "<ident>", comma: true },
+    "widows"                        : "<integer>",
+    "width"                         : "<length> | <percentage> | <content-sizing> | auto",
+    "will-change"                   : "<will-change>",
     "word-break"                    : "normal | keep-all | break-all",
-    "word-spacing"                  : "<length> | normal | inherit",
+    "word-spacing"                  : "<length> | normal",
     "word-wrap"                     : "normal | break-word",
-    "writing-mode"                  : "horizontal-tb | vertical-rl | vertical-lr | lr-tb | rl-tb | tb-rl | bt-rl | tb-lr | bt-lr | lr-bt | rl-bt | lr | rl | tb | inherit",
+    "writing-mode"                  : "horizontal-tb | vertical-rl | vertical-lr | lr-tb | rl-tb | tb-rl | bt-rl | tb-lr | bt-lr | lr-bt | rl-bt | lr | rl | tb",
 
     //Z
-    "z-index"                       : "<integer> | auto | inherit",
+    "z-index"                       : "<integer> | auto",
     "zoom"                          : "<number> | <percentage> | normal"
 };
 
-/*global SyntaxUnit, Parser*/
+},{}],8:[function(require,module,exports){
+"use strict";
+
+module.exports = PropertyName;
+
+var SyntaxUnit = require("../util/SyntaxUnit");
+
+var Parser = require("./Parser");
+
 /**
  * Represents a selector combinator (whitespace, +, >).
  * @namespace parserlib.css
@@ -4254,7 +3796,7 @@ var Properties = {
  * @param {int} line The line of text on which the unit resides.
  * @param {int} col The column of text on which the unit resides.
  */
-function PropertyName(text, hack, line, col){
+function PropertyName(text, hack, line, col) {
 
     SyntaxUnit.call(this, text, line, col, Parser.PROPERTY_NAME_TYPE);
 
@@ -4269,11 +3811,19 @@ function PropertyName(text, hack, line, col){
 
 PropertyName.prototype = new SyntaxUnit();
 PropertyName.prototype.constructor = PropertyName;
-PropertyName.prototype.toString = function(){
+PropertyName.prototype.toString = function() {
     return (this.hack ? this.hack : "") + this.text;
 };
 
-/*global SyntaxUnit, Parser*/
+},{"../util/SyntaxUnit":26,"./Parser":6}],9:[function(require,module,exports){
+"use strict";
+
+module.exports = PropertyValue;
+
+var SyntaxUnit = require("../util/SyntaxUnit");
+
+var Parser = require("./Parser");
+
 /**
  * Represents a single part of a CSS property value, meaning that it represents
  * just everything single part between ":" and ";". If there are multiple values
@@ -4286,7 +3836,7 @@ PropertyName.prototype.toString = function(){
  * @extends parserlib.util.SyntaxUnit
  * @constructor
  */
-function PropertyValue(parts, line, col){
+function PropertyValue(parts, line, col) {
 
     SyntaxUnit.call(this, parts.join(" "), line, col, Parser.PROPERTY_VALUE_TYPE);
 
@@ -4303,7 +3853,11 @@ PropertyValue.prototype = new SyntaxUnit();
 PropertyValue.prototype.constructor = PropertyValue;
 
 
-/*global SyntaxUnit, Parser*/
+},{"../util/SyntaxUnit":26,"./Parser":6}],10:[function(require,module,exports){
+"use strict";
+
+module.exports = PropertyValueIterator;
+
 /**
  * A utility class that allows for easy iteration over the various parts of a
  * property value.
@@ -4312,7 +3866,7 @@ PropertyValue.prototype.constructor = PropertyValue;
  * @class PropertyValueIterator
  * @constructor
  */
-function PropertyValueIterator(value){
+function PropertyValueIterator(value) {
 
     /**
      * Iterator value
@@ -4352,7 +3906,7 @@ function PropertyValueIterator(value){
  * @return {int} The total number of parts in the value.
  * @method count
  */
-PropertyValueIterator.prototype.count = function(){
+PropertyValueIterator.prototype.count = function() {
     return this._parts.length;
 };
 
@@ -4361,7 +3915,7 @@ PropertyValueIterator.prototype.count = function(){
  * @return {Boolean} True if positioned at first item, false if not.
  * @method isFirst
  */
-PropertyValueIterator.prototype.isFirst = function(){
+PropertyValueIterator.prototype.isFirst = function() {
     return this._i === 0;
 };
 
@@ -4370,8 +3924,8 @@ PropertyValueIterator.prototype.isFirst = function(){
  * @return {Boolean} True if there are more parts, false if not.
  * @method hasNext
  */
-PropertyValueIterator.prototype.hasNext = function(){
-    return (this._i < this._parts.length);
+PropertyValueIterator.prototype.hasNext = function() {
+    return this._i < this._parts.length;
 };
 
 /**
@@ -4380,7 +3934,7 @@ PropertyValueIterator.prototype.hasNext = function(){
  * @return {void}
  * @method mark
  */
-PropertyValueIterator.prototype.mark = function(){
+PropertyValueIterator.prototype.mark = function() {
     this._marks.push(this._i);
 };
 
@@ -4391,7 +3945,7 @@ PropertyValueIterator.prototype.mark = function(){
  * part.
  * @method peek
  */
-PropertyValueIterator.prototype.peek = function(count){
+PropertyValueIterator.prototype.peek = function(count) {
     return this.hasNext() ? this._parts[this._i + (count || 0)] : null;
 };
 
@@ -4402,7 +3956,7 @@ PropertyValueIterator.prototype.peek = function(count){
  * part.
  * @method next
  */
-PropertyValueIterator.prototype.next = function(){
+PropertyValueIterator.prototype.next = function() {
     return this.hasNext() ? this._parts[this._i++] : null;
 };
 
@@ -4410,10 +3964,10 @@ PropertyValueIterator.prototype.next = function(){
  * Returns the previous part of the property value or null if there is no
  * previous part.
  * @return {parserlib.css.PropertyValuePart} The previous part of the
- * property value or null if there is no next part.
+ * property value or null if there is no previous part.
  * @method previous
  */
-PropertyValueIterator.prototype.previous = function(){
+PropertyValueIterator.prototype.previous = function() {
     return this._i > 0 ? this._parts[--this._i] : null;
 };
 
@@ -4422,14 +3976,32 @@ PropertyValueIterator.prototype.previous = function(){
  * @return {void}
  * @method restore
  */
-PropertyValueIterator.prototype.restore = function(){
-    if (this._marks.length){
+PropertyValueIterator.prototype.restore = function() {
+    if (this._marks.length) {
         this._i = this._marks.pop();
     }
 };
 
+/**
+ * Drops the last saved bookmark.
+ * @return {void}
+ * @method drop
+ */
+PropertyValueIterator.prototype.drop = function() {
+    this._marks.pop();
+};
 
-/*global SyntaxUnit, Parser, Colors*/
+},{}],11:[function(require,module,exports){
+"use strict";
+
+module.exports = PropertyValuePart;
+
+var SyntaxUnit = require("../util/SyntaxUnit");
+
+var Colors = require("./Colors");
+var Parser = require("./Parser");
+var Tokens = require("./Tokens");
+
 /**
  * Represents a single part of a CSS property value, meaning that it represents
  * just one part of the data between ":" and ";".
@@ -4441,7 +4013,8 @@ PropertyValueIterator.prototype.restore = function(){
  * @extends parserlib.util.SyntaxUnit
  * @constructor
  */
-function PropertyValuePart(text, line, col){
+function PropertyValuePart(text, line, col, optionalHint) {
+    var hint = optionalHint || {};
 
     SyntaxUnit.call(this, text, line, col, Parser.PROPERTY_VALUE_PART_TYPE);
 
@@ -4457,13 +4030,13 @@ function PropertyValuePart(text, line, col){
     var temp;
 
     //it is a measurement?
-    if (/^([+\-]?[\d\.]+)([a-z]+)$/i.test(text)){  //dimension
+    if (/^([+\-]?[\d\.]+)([a-z]+)$/i.test(text)) {  //dimension
         this.type = "dimension";
         this.value = +RegExp.$1;
         this.units = RegExp.$2;
 
         //try to narrow down
-        switch(this.units.toLowerCase()){
+        switch (this.units.toLowerCase()) {
 
             case "em":
             case "rem":
@@ -4482,9 +4055,14 @@ function PropertyValuePart(text, line, col){
                 this.type = "length";
                 break;
 
+            case "fr":
+                this.type = "grid";
+                break;
+
             case "deg":
             case "rad":
             case "grad":
+            case "turn":
                 this.type = "angle";
                 break;
 
@@ -4507,92 +4085,141 @@ function PropertyValuePart(text, line, col){
 
         }
 
-    } else if (/^([+\-]?[\d\.]+)%$/i.test(text)){  //percentage
+    } else if (/^([+\-]?[\d\.]+)%$/i.test(text)) {  //percentage
         this.type = "percentage";
         this.value = +RegExp.$1;
-    } else if (/^([+\-]?\d+)$/i.test(text)){  //integer
+    } else if (/^([+\-]?\d+)$/i.test(text)) {  //integer
         this.type = "integer";
         this.value = +RegExp.$1;
-    } else if (/^([+\-]?[\d\.]+)$/i.test(text)){  //number
+    } else if (/^([+\-]?[\d\.]+)$/i.test(text)) {  //number
         this.type = "number";
         this.value = +RegExp.$1;
 
-    } else if (/^#([a-f0-9]{3,6})/i.test(text)){  //hexcolor
+    } else if (/^#([a-f0-9]{3,6})/i.test(text)) {  //hexcolor
         this.type = "color";
         temp = RegExp.$1;
-        if (temp.length == 3){
-            this.red    = parseInt(temp.charAt(0)+temp.charAt(0),16);
-            this.green  = parseInt(temp.charAt(1)+temp.charAt(1),16);
-            this.blue   = parseInt(temp.charAt(2)+temp.charAt(2),16);
+        if (temp.length === 3) {
+            this.red    = parseInt(temp.charAt(0)+temp.charAt(0), 16);
+            this.green  = parseInt(temp.charAt(1)+temp.charAt(1), 16);
+            this.blue   = parseInt(temp.charAt(2)+temp.charAt(2), 16);
         } else {
-            this.red    = parseInt(temp.substring(0,2),16);
-            this.green  = parseInt(temp.substring(2,4),16);
-            this.blue   = parseInt(temp.substring(4,6),16);
+            this.red    = parseInt(temp.substring(0, 2), 16);
+            this.green  = parseInt(temp.substring(2, 4), 16);
+            this.blue   = parseInt(temp.substring(4, 6), 16);
         }
-    } else if (/^rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/i.test(text)){ //rgb() color with absolute numbers
+    } else if (/^rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/i.test(text)) { //rgb() color with absolute numbers
         this.type   = "color";
         this.red    = +RegExp.$1;
         this.green  = +RegExp.$2;
         this.blue   = +RegExp.$3;
-    } else if (/^rgb\(\s*(\d+)%\s*,\s*(\d+)%\s*,\s*(\d+)%\s*\)/i.test(text)){ //rgb() color with percentages
+    } else if (/^rgb\(\s*(\d+)%\s*,\s*(\d+)%\s*,\s*(\d+)%\s*\)/i.test(text)) { //rgb() color with percentages
         this.type   = "color";
         this.red    = +RegExp.$1 * 255 / 100;
         this.green  = +RegExp.$2 * 255 / 100;
         this.blue   = +RegExp.$3 * 255 / 100;
-    } else if (/^rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([\d\.]+)\s*\)/i.test(text)){ //rgba() color with absolute numbers
+    } else if (/^rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([\d\.]+)\s*\)/i.test(text)) { //rgba() color with absolute numbers
         this.type   = "color";
         this.red    = +RegExp.$1;
         this.green  = +RegExp.$2;
         this.blue   = +RegExp.$3;
         this.alpha  = +RegExp.$4;
-    } else if (/^rgba\(\s*(\d+)%\s*,\s*(\d+)%\s*,\s*(\d+)%\s*,\s*([\d\.]+)\s*\)/i.test(text)){ //rgba() color with percentages
+    } else if (/^rgba\(\s*(\d+)%\s*,\s*(\d+)%\s*,\s*(\d+)%\s*,\s*([\d\.]+)\s*\)/i.test(text)) { //rgba() color with percentages
         this.type   = "color";
         this.red    = +RegExp.$1 * 255 / 100;
         this.green  = +RegExp.$2 * 255 / 100;
         this.blue   = +RegExp.$3 * 255 / 100;
         this.alpha  = +RegExp.$4;
-    } else if (/^hsl\(\s*(\d+)\s*,\s*(\d+)%\s*,\s*(\d+)%\s*\)/i.test(text)){ //hsl()
+    } else if (/^hsl\(\s*(\d+)\s*,\s*(\d+)%\s*,\s*(\d+)%\s*\)/i.test(text)) { //hsl()
         this.type   = "color";
         this.hue    = +RegExp.$1;
         this.saturation = +RegExp.$2 / 100;
         this.lightness  = +RegExp.$3 / 100;
-    } else if (/^hsla\(\s*(\d+)\s*,\s*(\d+)%\s*,\s*(\d+)%\s*,\s*([\d\.]+)\s*\)/i.test(text)){ //hsla() color with percentages
+    } else if (/^hsla\(\s*(\d+)\s*,\s*(\d+)%\s*,\s*(\d+)%\s*,\s*([\d\.]+)\s*\)/i.test(text)) { //hsla() color with percentages
         this.type   = "color";
         this.hue    = +RegExp.$1;
         this.saturation = +RegExp.$2 / 100;
         this.lightness  = +RegExp.$3 / 100;
         this.alpha  = +RegExp.$4;
-    } else if (/^url\(["']?([^\)"']+)["']?\)/i.test(text)){ //URI
+    } else if (/^url\(("([^\\"]|\\.)*")\)/i.test(text)) { //URI
+        // generated by TokenStream.readURI, so always double-quoted.
         this.type   = "uri";
-        this.uri    = RegExp.$1;
-    } else if (/^([^\(]+)\(/i.test(text)){
+        this.uri    = PropertyValuePart.parseString(RegExp.$1);
+    } else if (/^([^\(]+)\(/i.test(text)) {
         this.type   = "function";
         this.name   = RegExp.$1;
         this.value  = text;
-//    } else if (/^["'][^"']*["']/.test(text)){    //string
-//        this.type   = "string";
-//        this.value  = eval(text);
-    } else if (/^(["'])[^\1]*\1/.test(text)){    //string
+    } else if (/^"([^\n\r\f\\"]|\\\r\n|\\[^\r0-9a-f]|\\[0-9a-f]{1,6}(\r\n|[ \n\r\t\f])?)*"/i.test(text)) {    //double-quoted string
         this.type   = "string";
-        this.value  = /^(["'])([^\1]*)\1/.exec(text)[2];
-    } else if (Colors[text.toLowerCase()]){  //named color
+        this.value  = PropertyValuePart.parseString(text);
+    } else if (/^'([^\n\r\f\\']|\\\r\n|\\[^\r0-9a-f]|\\[0-9a-f]{1,6}(\r\n|[ \n\r\t\f])?)*'/i.test(text)) {    //single-quoted string
+        this.type   = "string";
+        this.value  = PropertyValuePart.parseString(text);
+    } else if (Colors[text.toLowerCase()]) {  //named color
         this.type   = "color";
         temp        = Colors[text.toLowerCase()].substring(1);
-        this.red    = parseInt(temp.substring(0,2),16);
-        this.green  = parseInt(temp.substring(2,4),16);
-        this.blue   = parseInt(temp.substring(4,6),16);
-    } else if (/^[\,\/]$/.test(text)){
+        this.red    = parseInt(temp.substring(0, 2), 16);
+        this.green  = parseInt(temp.substring(2, 4), 16);
+        this.blue   = parseInt(temp.substring(4, 6), 16);
+    } else if (/^[,\/]$/.test(text)) {
         this.type   = "operator";
         this.value  = text;
-    } else if (/^[a-z\-_\u0080-\uFFFF][a-z0-9\-_\u0080-\uFFFF]*$/i.test(text)){
+    } else if (/^-?[a-z_\u00A0-\uFFFF][a-z0-9\-_\u00A0-\uFFFF]*$/i.test(text)) {
         this.type   = "identifier";
         this.value  = text;
     }
+
+    // There can be ambiguity with escape sequences in identifiers, as
+    // well as with "color" parts which are also "identifiers", so record
+    // an explicit hint when the token generating this PropertyValuePart
+    // was an identifier.
+    this.wasIdent = Boolean(hint.ident);
 
 }
 
 PropertyValuePart.prototype = new SyntaxUnit();
 PropertyValuePart.prototype.constructor = PropertyValuePart;
+
+/**
+ * Helper method to parse a CSS string.
+ */
+PropertyValuePart.parseString = function(str) {
+    str = str.slice(1, -1); // Strip surrounding single/double quotes
+    var replacer = function(match, esc) {
+        if (/^(\n|\r\n|\r|\f)$/.test(esc)) {
+            return "";
+        }
+        var m = /^[0-9a-f]{1,6}/i.exec(esc);
+        if (m) {
+            var codePoint = parseInt(m[0], 16);
+            if (String.fromCodePoint) {
+                return String.fromCodePoint(codePoint);
+            } else {
+                // XXX No support for surrogates on old JavaScript engines.
+                return String.fromCharCode(codePoint);
+            }
+        }
+        return esc;
+    };
+    return str.replace(/\\(\r\n|[^\r0-9a-f]|[0-9a-f]{1,6}(\r\n|[ \n\r\t\f])?)/ig,
+                       replacer);
+};
+
+/**
+ * Helper method to serialize a CSS string.
+ */
+PropertyValuePart.serializeString = function(value) {
+    var replacer = function(match, c) {
+        if (c === "\"") {
+            return "\\" + c;
+        }
+        var cp = String.codePointAt ? String.codePointAt(0) :
+            // We only escape non-surrogate chars, so using charCodeAt
+            // is harmless here.
+            String.charCodeAt(0);
+        return "\\" + cp.toString(16) + " ";
+    };
+    return "\"" + value.replace(/["\r\n\f]/g, replacer) + "\"";
+};
 
 /**
  * Create a new syntax unit based solely on the given token.
@@ -4603,11 +4230,21 @@ PropertyValuePart.prototype.constructor = PropertyValuePart;
  * @static
  * @method fromToken
  */
-PropertyValuePart.fromToken = function(token){
-    return new PropertyValuePart(token.value, token.startLine, token.startCol);
+PropertyValuePart.fromToken = function(token) {
+    var part = new PropertyValuePart(token.value, token.startLine, token.startCol, {
+        // Tokens can have escaped characters that would fool the type
+        // identification in the PropertyValuePart constructor, so pass
+        // in a hint if this was an identifier.
+        ident: token.type === Tokens.IDENT
+    });
+    return part;
 };
 
-var Pseudos = {
+},{"../util/SyntaxUnit":26,"./Colors":1,"./Parser":6,"./Tokens":18}],12:[function(require,module,exports){
+"use strict";
+
+var Pseudos = module.exports = {
+    __proto__:       null,
     ":first-letter": 1,
     ":first-line":   1,
     ":before":       1,
@@ -4617,10 +4254,20 @@ var Pseudos = {
 Pseudos.ELEMENT = 1;
 Pseudos.CLASS = 2;
 
-Pseudos.isElement = function(pseudo){
-    return pseudo.indexOf("::") === 0 || Pseudos[pseudo.toLowerCase()] == Pseudos.ELEMENT;
+Pseudos.isElement = function(pseudo) {
+    return pseudo.indexOf("::") === 0 || Pseudos[pseudo.toLowerCase()] === Pseudos.ELEMENT;
 };
-/*global SyntaxUnit, Parser, Specificity*/
+
+},{}],13:[function(require,module,exports){
+"use strict";
+
+module.exports = Selector;
+
+var SyntaxUnit = require("../util/SyntaxUnit");
+
+var Parser = require("./Parser");
+var Specificity = require("./Specificity");
+
 /**
  * Represents an entire single selector, including all parts but not
  * including multiple selectors (those separated by commas).
@@ -4632,7 +4279,7 @@ Pseudos.isElement = function(pseudo){
  * @param {int} line The line of text on which the unit resides.
  * @param {int} col The column of text on which the unit resides.
  */
-function Selector(parts, line, col){
+function Selector(parts, line, col) {
 
     SyntaxUnit.call(this, parts.join(" "), line, col, Parser.SELECTOR_TYPE);
 
@@ -4656,7 +4303,15 @@ Selector.prototype = new SyntaxUnit();
 Selector.prototype.constructor = Selector;
 
 
-/*global SyntaxUnit, Parser*/
+},{"../util/SyntaxUnit":26,"./Parser":6,"./Specificity":16}],14:[function(require,module,exports){
+"use strict";
+
+module.exports = SelectorPart;
+
+var SyntaxUnit = require("../util/SyntaxUnit");
+
+var Parser = require("./Parser");
+
 /**
  * Represents a single part of a selector string, meaning a single set of
  * element name and modifiers. This does not include combinators such as
@@ -4673,7 +4328,7 @@ Selector.prototype.constructor = Selector;
  * @param {int} line The line of text on which the unit resides.
  * @param {int} col The column of text on which the unit resides.
  */
-function SelectorPart(elementName, modifiers, text, line, col){
+function SelectorPart(elementName, modifiers, text, line, col) {
 
     SyntaxUnit.call(this, text, line, col, Parser.SELECTOR_PART_TYPE);
 
@@ -4699,7 +4354,15 @@ SelectorPart.prototype = new SyntaxUnit();
 SelectorPart.prototype.constructor = SelectorPart;
 
 
-/*global SyntaxUnit, Parser*/
+},{"../util/SyntaxUnit":26,"./Parser":6}],15:[function(require,module,exports){
+"use strict";
+
+module.exports = SelectorSubPart;
+
+var SyntaxUnit = require("../util/SyntaxUnit");
+
+var Parser = require("./Parser");
+
 /**
  * Represents a selector modifier string, meaning a class name, element name,
  * element ID, pseudo rule, etc.
@@ -4712,7 +4375,7 @@ SelectorPart.prototype.constructor = SelectorPart;
  * @param {int} line The line of text on which the unit resides.
  * @param {int} col The column of text on which the unit resides.
  */
-function SelectorSubPart(text, type, line, col){
+function SelectorSubPart(text, type, line, col) {
 
     SyntaxUnit.call(this, text, line, col, Parser.SELECTOR_SUB_PART_TYPE);
 
@@ -4736,7 +4399,14 @@ SelectorSubPart.prototype = new SyntaxUnit();
 SelectorSubPart.prototype.constructor = SelectorSubPart;
 
 
-/*global Pseudos, SelectorPart*/
+},{"../util/SyntaxUnit":26,"./Parser":6}],16:[function(require,module,exports){
+"use strict";
+
+module.exports = Specificity;
+
+var Pseudos = require("./Pseudos");
+var SelectorPart = require("./SelectorPart");
+
 /**
  * Represents a selector's specificity.
  * @namespace parserlib.css
@@ -4747,7 +4417,7 @@ SelectorSubPart.prototype.constructor = SelectorSubPart;
  * @param {int} c Number of classes and pseudo classes
  * @param {int} d Number of element names and pseudo elements
  */
-function Specificity(a, b, c, d){
+function Specificity(a, b, c, d) {
     this.a = a;
     this.b = b;
     this.c = c;
@@ -4763,14 +4433,14 @@ Specificity.prototype = {
      * @return {int} -1 if the other specificity is larger, 1 if smaller, 0 if equal.
      * @method compare
      */
-    compare: function(other){
+    compare: function(other) {
         var comps = ["a", "b", "c", "d"],
             i, len;
 
-        for (i=0, len=comps.length; i < len; i++){
-            if (this[comps[i]] < other[comps[i]]){
+        for (i=0, len=comps.length; i < len; i++) {
+            if (this[comps[i]] < other[comps[i]]) {
                 return -1;
-            } else if (this[comps[i]] > other[comps[i]]){
+            } else if (this[comps[i]] > other[comps[i]]) {
                 return 1;
             }
         }
@@ -4783,7 +4453,7 @@ Specificity.prototype = {
      * @return {int} The numeric value for the specificity.
      * @method valueOf
      */
-    valueOf: function(){
+    valueOf: function() {
         return (this.a * 1000) + (this.b * 100) + (this.c * 10) + this.d;
     },
 
@@ -4792,7 +4462,7 @@ Specificity.prototype = {
      * @return {String} The string representation of specificity.
      * @method toString
      */
-    toString: function(){
+    toString: function() {
         return this.a + "," + this.b + "," + this.c + "," + this.d;
     }
 
@@ -4805,25 +4475,25 @@ Specificity.prototype = {
  * @static
  * @method calculate
  */
-Specificity.calculate = function(selector){
+Specificity.calculate = function(selector) {
 
     var i, len,
         part,
         b=0, c=0, d=0;
 
-    function updateValues(part){
+    function updateValues(part) {
 
         var i, j, len, num,
             elementName = part.elementName ? part.elementName.text : "",
             modifier;
 
-        if (elementName && elementName.charAt(elementName.length-1) != "*") {
+        if (elementName && elementName.charAt(elementName.length-1) !== "*") {
             d++;
         }
 
-        for (i=0, len=part.modifiers.length; i < len; i++){
+        for (i=0, len=part.modifiers.length; i < len; i++) {
             modifier = part.modifiers[i];
-            switch(modifier.type){
+            switch (modifier.type) {
                 case "class":
                 case "attribute":
                     c++;
@@ -4834,7 +4504,7 @@ Specificity.calculate = function(selector){
                     break;
 
                 case "pseudo":
-                    if (Pseudos.isElement(modifier.text)){
+                    if (Pseudos.isElement(modifier.text)) {
                         d++;
                     } else {
                         c++;
@@ -4842,17 +4512,17 @@ Specificity.calculate = function(selector){
                     break;
 
                 case "not":
-                    for (j=0, num=modifier.args.length; j < num; j++){
+                    for (j=0, num=modifier.args.length; j < num; j++) {
                         updateValues(modifier.args[j]);
                     }
             }
-         }
+        }
     }
 
-    for (i=0, len=selector.parts.length; i < len; i++){
+    for (i=0, len=selector.parts.length; i < len; i++) {
         part = selector.parts[i];
 
-        if (part instanceof SelectorPart){
+        if (part instanceof SelectorPart) {
             updateValues(part);
         }
     }
@@ -4860,52 +4530,61 @@ Specificity.calculate = function(selector){
     return new Specificity(0, b, c, d);
 };
 
-/*global Tokens, TokenStreamBase*/
+},{"./Pseudos":12,"./SelectorPart":14}],17:[function(require,module,exports){
+"use strict";
+
+module.exports = TokenStream;
+
+var TokenStreamBase = require("../util/TokenStreamBase");
+
+var PropertyValuePart = require("./PropertyValuePart");
+var Tokens = require("./Tokens");
 
 var h = /^[0-9a-fA-F]$/,
-    nonascii = /^[\u0080-\uFFFF]$/,
-    nl = /\n|\r\n|\r|\f/;
+    nonascii = /^[\u00A0-\uFFFF]$/,
+    nl = /\n|\r\n|\r|\f/,
+    whitespace = /\u0009|\u000a|\u000c|\u000d|\u0020/;
 
 //-----------------------------------------------------------------------------
 // Helper functions
 //-----------------------------------------------------------------------------
 
 
-function isHexDigit(c){
+function isHexDigit(c) {
     return c !== null && h.test(c);
 }
 
-function isDigit(c){
+function isDigit(c) {
     return c !== null && /\d/.test(c);
 }
 
-function isWhitespace(c){
-    return c !== null && /\s/.test(c);
+function isWhitespace(c) {
+    return c !== null && whitespace.test(c);
 }
 
-function isNewLine(c){
+function isNewLine(c) {
     return c !== null && nl.test(c);
 }
 
-function isNameStart(c){
-    return c !== null && (/[a-z_\u0080-\uFFFF\\]/i.test(c));
+function isNameStart(c) {
+    return c !== null && /[a-z_\u00A0-\uFFFF\\]/i.test(c);
 }
 
-function isNameChar(c){
+function isNameChar(c) {
     return c !== null && (isNameStart(c) || /[0-9\-\\]/.test(c));
 }
 
-function isIdentStart(c){
+function isIdentStart(c) {
     return c !== null && (isNameStart(c) || /\-\\/.test(c));
 }
 
-function mix(receiver, supplier){
-	for (var prop in supplier){
-		if (supplier.hasOwnProperty(prop)){
-			receiver[prop] = supplier[prop];
-		}
-	}
-	return receiver;
+function mix(receiver, supplier) {
+    for (var prop in supplier) {
+        if (Object.prototype.hasOwnProperty.call(supplier, prop)) {
+            receiver[prop] = supplier[prop];
+        }
+    }
+    return receiver;
 }
 
 //-----------------------------------------------------------------------------
@@ -4920,8 +4599,8 @@ function mix(receiver, supplier){
  * @class TokenStream
  * @namespace parserlib.css
  */
-function TokenStream(input){
-	TokenStreamBase.call(this, input, Tokens);
+function TokenStream(input) {
+    TokenStreamBase.call(this, input, Tokens);
 }
 
 TokenStream.prototype = mix(new TokenStreamBase(), {
@@ -4929,13 +4608,11 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
     /**
      * Overrides the TokenStreamBase method of the same name
      * to produce CSS tokens.
-     * @param {variant} channel The name of the channel to use
-     *      for the next token.
      * @return {Object} A token object representing the next token.
      * @method _getToken
      * @private
      */
-    _getToken: function(channel){
+    _getToken: function() {
 
         var c,
             reader = this._reader,
@@ -4946,8 +4623,8 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
         c = reader.read();
 
 
-        while(c){
-            switch(c){
+        while (c) {
+            switch (c) {
 
                 /*
                  * Potential tokens:
@@ -4957,7 +4634,7 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
                  */
                 case "/":
 
-                    if(reader.peek() == "*"){
+                    if (reader.peek() === "*") {
                         token = this.commentToken(c, startLine, startCol);
                     } else {
                         token = this.charToken(c, startLine, startCol);
@@ -4978,7 +4655,7 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
                 case "^":
                 case "$":
                 case "*":
-                    if(reader.peek() == "="){
+                    if (reader.peek() === "=") {
                         token = this.comparisonToken(c, startLine, startCol);
                     } else {
                         token = this.charToken(c, startLine, startCol);
@@ -5001,7 +4678,7 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
                  * - CHAR
                  */
                 case "#":
-                    if (isNameChar(reader.peek())){
+                    if (isNameChar(reader.peek())) {
                         token = this.hashToken(c, startLine, startCol);
                     } else {
                         token = this.charToken(c, startLine, startCol);
@@ -5016,7 +4693,7 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
                  * - PERCENTAGE
                  */
                 case ".":
-                    if (isDigit(reader.peek())){
+                    if (isDigit(reader.peek())) {
                         token = this.numberToken(c, startLine, startCol);
                     } else {
                         token = this.charToken(c, startLine, startCol);
@@ -5032,9 +4709,9 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
                  * - PERCENTAGE
                  */
                 case "-":
-                    if (reader.peek() == "-"){  //could be closing HTML-style comment
+                    if (reader.peek() === "-") {  //could be closing HTML-style comment
                         token = this.htmlCommentEndToken(c, startLine, startCol);
-                    } else if (isNameStart(reader.peek())){
+                    } else if (isNameStart(reader.peek())) {
                         token = this.identOrFunctionToken(c, startLine, startCol);
                     } else {
                         token = this.charToken(c, startLine, startCol);
@@ -5077,13 +4754,26 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
 
                 /*
                  * Potential tokens:
+                 * - IDENT
+                 * - CHAR
+                 */
+                case "\\":
+                    if (/[^\r\n\f]/.test(reader.peek())) {
+                        token = this.identOrFunctionToken(this.readEscape(c, true), startLine, startCol);
+                    } else {
+                        token = this.charToken(c, startLine, startCol);
+                    }
+                    break;
+
+                /*
+                 * Potential tokens:
                  * - UNICODE_RANGE
                  * - URL
                  * - CHAR
                  */
                 case "U":
                 case "u":
-                    if (reader.peek() == "+"){
+                    if (reader.peek() === "+") {
                         token = this.unicodeRangeToken(c, startLine, startCol);
                         break;
                     }
@@ -5101,7 +4791,7 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
                      * - EXS
                      * - ANGLE
                      */
-                    if (isDigit(c)){
+                    if (isDigit(c)) {
                         token = this.numberToken(c, startLine, startCol);
                     } else
 
@@ -5109,7 +4799,7 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
                      * Potential tokens:
                      * - S
                      */
-                    if (isWhitespace(c)){
+                    if (isWhitespace(c)) {
                         token = this.whitespaceToken(c, startLine, startCol);
                     } else
 
@@ -5117,23 +4807,16 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
                      * Potential tokens:
                      * - IDENT
                      */
-                    if (isIdentStart(c)){
+                    if (isIdentStart(c)) {
                         token = this.identOrFunctionToken(c, startLine, startCol);
-                    } else
-
-                    /*
-                     * Potential tokens:
-                     * - CHAR
-                     * - PLUS
-                     */
-                    {
+                    } else {
+                       /*
+                        * Potential tokens:
+                        * - CHAR
+                        * - PLUS
+                        */
                         token = this.charToken(c, startLine, startCol);
                     }
-
-
-
-
-
 
             }
 
@@ -5142,8 +4825,8 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
             break;
         }
 
-        if (!token && c === null){
-            token = this.createToken(Tokens.EOF,null,startLine,startCol);
+        if (!token && c === null) {
+            token = this.createToken(Tokens.EOF, null, startLine, startCol);
         }
 
         return token;
@@ -5168,7 +4851,7 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
      * @return {Object} A token object.
      * @method createToken
      */
-    createToken: function(tt, value, startLine, startCol, options){
+    createToken: function(tt, value, startLine, startCol, options) {
         var reader = this._reader;
         options = options || {};
 
@@ -5198,13 +4881,11 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
      * @return {Object} A token object.
      * @method atRuleToken
      */
-    atRuleToken: function(first, startLine, startCol){
+    atRuleToken: function(first, startLine, startCol) {
         var rule    = first,
             reader  = this._reader,
             tt      = Tokens.CHAR,
-            valid   = false,
-            ident,
-            c;
+            ident;
 
         /*
          * First, mark where we are. There are only four @ rules,
@@ -5221,8 +4902,8 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
         tt = Tokens.type(rule.toLowerCase());
 
         //if it's not valid, use the first character only and reset the reader
-        if (tt == Tokens.CHAR || tt == Tokens.UNKNOWN){
-            if (rule.length > 1){
+        if (tt === Tokens.CHAR || tt === Tokens.UNKNOWN) {
+            if (rule.length > 1) {
                 tt = Tokens.UNKNOWN_SYM;
             } else {
                 tt = Tokens.CHAR;
@@ -5244,11 +4925,11 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
      * @return {Object} A token object.
      * @method charToken
      */
-    charToken: function(c, startLine, startCol){
+    charToken: function(c, startLine, startCol) {
         var tt = Tokens.type(c);
         var opts = {};
 
-        if (tt == -1){
+        if (tt === -1) {
             tt = Tokens.CHAR;
         } else {
             opts.endChar = Tokens[tt].endChar;
@@ -5267,9 +4948,8 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
      * @return {Object} A token object.
      * @method commentToken
      */
-    commentToken: function(first, startLine, startCol){
-        var reader  = this._reader,
-            comment = this.readComment(first);
+    commentToken: function(first, startLine, startCol) {
+        var comment = this.readComment(first);
 
         return this.createToken(Tokens.COMMENT, comment, startLine, startCol);
     },
@@ -5284,7 +4964,7 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
      * @return {Object} A token object.
      * @method comparisonToken
      */
-    comparisonToken: function(c, startLine, startCol){
+    comparisonToken: function(c, startLine, startCol) {
         var reader  = this._reader,
             comparison  = c + reader.read(),
             tt      = Tokens.type(comparison) || Tokens.CHAR;
@@ -5302,9 +4982,8 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
      * @return {Object} A token object.
      * @method hashToken
      */
-    hashToken: function(first, startLine, startCol){
-        var reader  = this._reader,
-            name    = this.readName(first);
+    hashToken: function(first, startLine, startCol) {
+        var name    = this.readName(first);
 
         return this.createToken(Tokens.HASH, name, startLine, startCol);
     },
@@ -5319,14 +4998,14 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
      * @return {Object} A token object.
      * @method htmlCommentStartToken
      */
-    htmlCommentStartToken: function(first, startLine, startCol){
+    htmlCommentStartToken: function(first, startLine, startCol) {
         var reader      = this._reader,
             text        = first;
 
         reader.mark();
         text += reader.readCount(3);
 
-        if (text == "<!--"){
+        if (text === "<!--") {
             return this.createToken(Tokens.CDO, text, startLine, startCol);
         } else {
             reader.reset();
@@ -5344,14 +5023,14 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
      * @return {Object} A token object.
      * @method htmlCommentEndToken
      */
-    htmlCommentEndToken: function(first, startLine, startCol){
+    htmlCommentEndToken: function(first, startLine, startCol) {
         var reader      = this._reader,
             text        = first;
 
         reader.mark();
         text += reader.readCount(2);
 
-        if (text == "-->"){
+        if (text === "-->") {
             return this.createToken(Tokens.CDC, text, startLine, startCol);
         } else {
             reader.reset();
@@ -5369,30 +5048,34 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
      * @return {Object} A token object.
      * @method identOrFunctionToken
      */
-    identOrFunctionToken: function(first, startLine, startCol){
+    identOrFunctionToken: function(first, startLine, startCol) {
         var reader  = this._reader,
             ident   = this.readName(first),
             tt      = Tokens.IDENT,
-            uriFns  = ["url(", "url-prefix(", "domain("];
+            uriFns  = ["url(", "url-prefix(", "domain("],
+            uri;
 
         //if there's a left paren immediately after, it's a URI or function
-        if (reader.peek() == "("){
+        if (reader.peek() === "(") {
             ident += reader.read();
-            if (uriFns.indexOf(ident.toLowerCase()) > -1){
-                tt = Tokens.URI;
-                ident = this.readURI(ident);
-
-                //didn't find a valid URL or there's no closing paren
-                if (uriFns.indexOf(ident.toLowerCase()) > -1){
+            if (uriFns.indexOf(ident.toLowerCase()) > -1) {
+                reader.mark();
+                uri = this.readURI(ident);
+                if (uri === null) {
+                    //didn't find a valid URL or there's no closing paren
+                    reader.reset();
                     tt = Tokens.FUNCTION;
+                } else {
+                    tt = Tokens.URI;
+                    ident = uri;
                 }
             } else {
                 tt = Tokens.FUNCTION;
             }
-        } else if (reader.peek() == ":"){  //might be an IE function
+        } else if (reader.peek() === ":") {  //might be an IE function
 
             //IE-specific functions always being with progid:
-            if (ident.toLowerCase() == "progid"){
+            if (ident.toLowerCase() === "progid") {
                 ident += reader.readTo("(");
                 tt = Tokens.IE_FUNCTION;
             }
@@ -5411,7 +5094,7 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
      * @return {Object} A token object.
      * @method importantToken
      */
-    importantToken: function(first, startLine, startCol){
+    importantToken: function(first, startLine, startCol) {
         var reader      = this._reader,
             important   = first,
             tt          = Tokens.CHAR,
@@ -5421,25 +5104,25 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
         reader.mark();
         c = reader.read();
 
-        while(c){
+        while (c) {
 
             //there can be a comment in here
-            if (c == "/"){
+            if (c === "/") {
 
                 //if the next character isn't a star, then this isn't a valid !important token
-                if (reader.peek() != "*"){
+                if (reader.peek() !== "*") {
                     break;
                 } else {
                     temp = this.readComment(c);
-                    if (temp === ""){    //broken!
+                    if (temp === "") {    //broken!
                         break;
                     }
                 }
-            } else if (isWhitespace(c)){
+            } else if (isWhitespace(c)) {
                 important += c + this.readWhitespace();
-            } else if (/i/i.test(c)){
+            } else if (/i/i.test(c)) {
                 temp = reader.readCount(8);
-                if (/mportant/i.test(temp)){
+                if (/mportant/i.test(temp)) {
                     important += c + temp;
                     tt = Tokens.IMPORTANT_SYM;
 
@@ -5452,7 +5135,7 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
             c = reader.read();
         }
 
-        if (tt == Tokens.CHAR){
+        if (tt === Tokens.CHAR) {
             reader.reset();
             return this.charToken(first, startLine, startCol);
         } else {
@@ -5472,14 +5155,14 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
      * @return {Object} A token object.
      * @method notToken
      */
-    notToken: function(first, startLine, startCol){
+    notToken: function(first, startLine, startCol) {
         var reader      = this._reader,
             text        = first;
 
         reader.mark();
         text += reader.readCount(4);
 
-        if (text.toLowerCase() == ":not("){
+        if (text.toLowerCase() === ":not(") {
             return this.createToken(Tokens.NOT, text, startLine, startCol);
         } else {
             reader.reset();
@@ -5498,32 +5181,32 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
      * @return {Object} A token object.
      * @method numberToken
      */
-    numberToken: function(first, startLine, startCol){
+    numberToken: function(first, startLine, startCol) {
         var reader  = this._reader,
             value   = this.readNumber(first),
             ident,
             tt      = Tokens.NUMBER,
             c       = reader.peek();
 
-        if (isIdentStart(c)){
+        if (isIdentStart(c)) {
             ident = this.readName(reader.read());
             value += ident;
 
-            if (/^em$|^ex$|^px$|^gd$|^rem$|^vw$|^vh$|^vmax$|^vmin$|^ch$|^cm$|^mm$|^in$|^pt$|^pc$/i.test(ident)){
+            if (/^em$|^ex$|^px$|^gd$|^rem$|^vw$|^vh$|^vmax$|^vmin$|^ch$|^cm$|^mm$|^in$|^pt$|^pc$/i.test(ident)) {
                 tt = Tokens.LENGTH;
-            } else if (/^deg|^rad$|^grad$/i.test(ident)){
+            } else if (/^deg|^rad$|^grad$|^turn$/i.test(ident)) {
                 tt = Tokens.ANGLE;
-            } else if (/^ms$|^s$/i.test(ident)){
+            } else if (/^ms$|^s$/i.test(ident)) {
                 tt = Tokens.TIME;
-            } else if (/^hz$|^khz$/i.test(ident)){
+            } else if (/^hz$|^khz$/i.test(ident)) {
                 tt = Tokens.FREQ;
-            } else if (/^dpi$|^dpcm$/i.test(ident)){
+            } else if (/^dpi$|^dpcm$/i.test(ident)) {
                 tt = Tokens.RESOLUTION;
             } else {
                 tt = Tokens.DIMENSION;
             }
 
-        } else if (c == "%"){
+        } else if (c === "%") {
             value += reader.read();
             tt = Tokens.PERCENTAGE;
         }
@@ -5544,70 +5227,90 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
      * @return {Object} A token object.
      * @method stringToken
      */
-    stringToken: function(first, startLine, startCol){
+    stringToken: function(first, startLine, startCol) {
         var delim   = first,
             string  = first,
             reader  = this._reader,
-            prev    = first,
             tt      = Tokens.STRING,
-            c       = reader.read();
+            c       = reader.read(),
+            i;
 
-        while(c){
+        while (c) {
             string += c;
 
-            //if the delimiter is found with an escapement, we're done.
-            if (c == delim && prev != "\\"){
-                break;
-            }
-
-            //if there's a newline without an escapement, it's an invalid string
-            if (isNewLine(reader.peek()) && c != "\\"){
+            if (c === "\\") {
+                c = reader.read();
+                if (c === null) {
+                    break; // premature EOF after backslash
+                } else if (/[^\r\n\f0-9a-f]/i.test(c)) {
+                    // single-character escape
+                    string += c;
+                } else {
+                    // read up to six hex digits
+                    for (i=0; isHexDigit(c) && i<6; i++) {
+                        string += c;
+                        c = reader.read();
+                    }
+                    // swallow trailing newline or space
+                    if (c === "\r" && reader.peek() === "\n") {
+                        string += c;
+                        c = reader.read();
+                    }
+                    if (isWhitespace(c)) {
+                        string += c;
+                    } else {
+                        // This character is null or not part of the escape;
+                        // jump back to the top to process it.
+                        continue;
+                    }
+                }
+            } else if (c === delim) {
+                break; // delimiter found.
+            } else if (isNewLine(reader.peek())) {
+                // newline without an escapement: it's an invalid string
                 tt = Tokens.INVALID;
                 break;
             }
-
-            //save previous and get next
-            prev = c;
             c = reader.read();
         }
 
         //if c is null, that means we're out of input and the string was never closed
-        if (c === null){
+        if (c === null) {
             tt = Tokens.INVALID;
         }
 
         return this.createToken(tt, string, startLine, startCol);
     },
 
-    unicodeRangeToken: function(first, startLine, startCol){
+    unicodeRangeToken: function(first, startLine, startCol) {
         var reader  = this._reader,
             value   = first,
             temp,
             tt      = Tokens.CHAR;
 
         //then it should be a unicode range
-        if (reader.peek() == "+"){
+        if (reader.peek() === "+") {
             reader.mark();
             value += reader.read();
             value += this.readUnicodeRangePart(true);
 
             //ensure there's an actual unicode range here
-            if (value.length == 2){
+            if (value.length === 2) {
                 reader.reset();
             } else {
 
                 tt = Tokens.UNICODE_RANGE;
 
                 //if there's a ? in the first part, there can't be a second part
-                if (value.indexOf("?") == -1){
+                if (value.indexOf("?") === -1) {
 
-                    if (reader.peek() == "-"){
+                    if (reader.peek() === "-") {
                         reader.mark();
                         temp = reader.read();
                         temp += this.readUnicodeRangePart(false);
 
                         //if there's not another value, back up and just take the first
-                        if (temp.length == 1){
+                        if (temp.length === 1) {
                             reader.reset();
                         } else {
                             value += temp;
@@ -5631,34 +5334,31 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
      * @return {Object} A token object.
      * @method whitespaceToken
      */
-    whitespaceToken: function(first, startLine, startCol){
-        var reader  = this._reader,
-            value   = first + this.readWhitespace();
+    whitespaceToken: function(first, startLine, startCol) {
+        var value   = first + this.readWhitespace();
         return this.createToken(Tokens.S, value, startLine, startCol);
     },
-
-
 
 
     //-------------------------------------------------------------------------
     // Methods to read values from the string stream
     //-------------------------------------------------------------------------
 
-    readUnicodeRangePart: function(allowQuestionMark){
+    readUnicodeRangePart: function(allowQuestionMark) {
         var reader  = this._reader,
             part = "",
             c       = reader.peek();
 
         //first read hex digits
-        while(isHexDigit(c) && part.length < 6){
+        while (isHexDigit(c) && part.length < 6) {
             reader.read();
             part += c;
             c = reader.peek();
         }
 
         //then read question marks if allowed
-        if (allowQuestionMark){
-            while(c == "?" && part.length < 6){
+        if (allowQuestionMark) {
+            while (c === "?" && part.length < 6) {
                 reader.read();
                 part += c;
                 c = reader.peek();
@@ -5670,12 +5370,12 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
         return part;
     },
 
-    readWhitespace: function(){
+    readWhitespace: function() {
         var reader  = this._reader,
             whitespace = "",
             c       = reader.peek();
 
-        while(isWhitespace(c)){
+        while (isWhitespace(c)) {
             reader.read();
             whitespace += c;
             c = reader.peek();
@@ -5683,18 +5383,18 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
 
         return whitespace;
     },
-    readNumber: function(first){
+    readNumber: function(first) {
         var reader  = this._reader,
             number  = first,
-            hasDot  = (first == "."),
+            hasDot  = (first === "."),
             c       = reader.peek();
 
 
-        while(c){
-            if (isDigit(c)){
+        while (c) {
+            if (isDigit(c)) {
                 number += reader.read();
-            } else if (c == "."){
-                if (hasDot){
+            } else if (c === ".") {
+                if (hasDot) {
                     break;
                 } else {
                     hasDot = true;
@@ -5709,105 +5409,99 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
 
         return number;
     },
-    readString: function(){
-        var reader  = this._reader,
-            delim   = reader.read(),
-            string  = delim,
-            prev    = delim,
-            c       = reader.peek();
 
-        while(c){
-            c = reader.read();
-            string += c;
-
-            //if the delimiter is found with an escapement, we're done.
-            if (c == delim && prev != "\\"){
-                break;
-            }
-
-            //if there's a newline without an escapement, it's an invalid string
-            if (isNewLine(reader.peek()) && c != "\\"){
-                string = "";
-                break;
-            }
-
-            //save previous and get next
-            prev = c;
-            c = reader.peek();
-        }
-
-        //if c is null, that means we're out of input and the string was never closed
-        if (c === null){
-            string = "";
-        }
-
-        return string;
+    // returns null w/o resetting reader if string is invalid.
+    readString: function() {
+        var token = this.stringToken(this._reader.read(), 0, 0);
+        return token.type === Tokens.INVALID ? null : token.value;
     },
-    readURI: function(first){
+
+    // returns null w/o resetting reader if URI is invalid.
+    readURI: function(first) {
         var reader  = this._reader,
             uri     = first,
             inner   = "",
             c       = reader.peek();
 
-        reader.mark();
-
         //skip whitespace before
-        while(c && isWhitespace(c)){
+        while (c && isWhitespace(c)) {
             reader.read();
             c = reader.peek();
         }
 
         //it's a string
-        if (c == "'" || c == "\""){
+        if (c === "'" || c === "\"") {
             inner = this.readString();
+            if (inner !== null) {
+                inner = PropertyValuePart.parseString(inner);
+            }
         } else {
-            inner = this.readURL();
+            inner = this.readUnquotedURL();
         }
 
         c = reader.peek();
 
         //skip whitespace after
-        while(c && isWhitespace(c)){
+        while (c && isWhitespace(c)) {
             reader.read();
             c = reader.peek();
         }
 
         //if there was no inner value or the next character isn't closing paren, it's not a URI
-        if (inner === "" || c != ")"){
-            uri = first;
-            reader.reset();
+        if (inner === null || c !== ")") {
+            uri = null;
         } else {
-            uri += inner + reader.read();
+            // Ensure argument to URL is always double-quoted
+            // (This simplifies later processing in PropertyValuePart.)
+            uri += PropertyValuePart.serializeString(inner) + reader.read();
         }
 
         return uri;
     },
-    readURL: function(){
+    // This method never fails, although it may return an empty string.
+    readUnquotedURL: function(first) {
         var reader  = this._reader,
-            url     = "",
-            c       = reader.peek();
+            url     = first || "",
+            c;
 
-        //TODO: Check for escape and nonascii
-        while (/^[!#$%&\\*-~]$/.test(c)){
-            url += reader.read();
-            c = reader.peek();
+        for (c = reader.peek(); c; c = reader.peek()) {
+            // Note that the grammar at
+            // https://www.w3.org/TR/CSS2/grammar.html#scanner
+            // incorrectly includes the backslash character in the
+            // `url` production, although it is correctly omitted in
+            // the `baduri1` production.
+            if (nonascii.test(c) || /^[\-!#$%&*-\[\]-~]$/.test(c)) {
+                url += c;
+                reader.read();
+            } else if (c === "\\") {
+                if (/^[^\r\n\f]$/.test(reader.peek(2))) {
+                    url += this.readEscape(reader.read(), true);
+                } else {
+                    break; // bad escape sequence.
+                }
+            } else {
+                break; // bad character
+            }
         }
 
         return url;
-
     },
-    readName: function(first){
+
+    readName: function(first) {
         var reader  = this._reader,
             ident   = first || "",
-            c       = reader.peek();
+            c;
 
-        while(true){
-            if (c == "\\"){
-                ident += this.readEscape(reader.read());
-                c = reader.peek();
-            } else if(c && isNameChar(c)){
+        for (c = reader.peek(); c; c = reader.peek()) {
+            if (c === "\\") {
+                if (/^[^\r\n\f]$/.test(reader.peek(2))) {
+                    ident += this.readEscape(reader.read(), true);
+                } else {
+                    // Bad escape sequence.
+                    break;
+                }
+            } else if (isNameChar(c)) {
                 ident += reader.read();
-                c = reader.peek();
             } else {
                 break;
             }
@@ -5816,40 +5510,60 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
         return ident;
     },
 
-    readEscape: function(first){
+    readEscape: function(first, unescape) {
         var reader  = this._reader,
             cssEscape = first || "",
             i       = 0,
             c       = reader.peek();
 
-        if (isHexDigit(c)){
+        if (isHexDigit(c)) {
             do {
                 cssEscape += reader.read();
                 c = reader.peek();
-            } while(c && isHexDigit(c) && ++i < 6);
+            } while (c && isHexDigit(c) && ++i < 6);
         }
 
-        if (cssEscape.length == 3 && /\s/.test(c) ||
-            cssEscape.length == 7 || cssEscape.length == 1){
+        if (cssEscape.length === 1) {
+            if (/^[^\r\n\f0-9a-f]$/.test(c)) {
                 reader.read();
+                if (unescape) {
+                    return c;
+                }
+            } else {
+                // We should never get here (readName won't call readEscape
+                // if the escape sequence is bad).
+                throw new Error("Bad escape sequence.");
+            }
+        } else if (c === "\r") {
+            reader.read();
+            if (reader.peek() === "\n") {
+                c += reader.read();
+            }
+        } else if (/^[ \t\n\f]$/.test(c)) {
+            reader.read();
         } else {
             c = "";
         }
 
+        if (unescape) {
+            var cp = parseInt(cssEscape.slice(first.length), 16);
+            return String.fromCodePoint ? String.fromCodePoint(cp) :
+                String.fromCharCode(cp);
+        }
         return cssEscape + c;
     },
 
-    readComment: function(first){
+    readComment: function(first) {
         var reader  = this._reader,
             comment = first || "",
             c       = reader.read();
 
-        if (c == "*"){
-            while(c){
+        if (c === "*") {
+            while (c) {
                 comment += c;
 
                 //look for end of comment
-                if (comment.length > 2 && c == "*" && reader.peek() == "/"){
+                if (comment.length > 2 && c === "*" && reader.peek() === "/") {
                     comment += reader.read();
                     break;
                 }
@@ -5865,123 +5579,126 @@ TokenStream.prototype = mix(new TokenStreamBase(), {
     }
 });
 
+},{"../util/TokenStreamBase":27,"./PropertyValuePart":11,"./Tokens":18}],18:[function(require,module,exports){
+"use strict";
 
-var Tokens  = [
+var Tokens = module.exports = [
 
     /*
-     * The following token names are defined in CSS3 Grammar: http://www.w3.org/TR/css3-syntax/#lexical
+     * The following token names are defined in CSS3 Grammar: https://www.w3.org/TR/css3-syntax/#lexical
      */
 
-    //HTML-style comments
-    { name: "CDO"},
-    { name: "CDC"},
+    // HTML-style comments
+    { name: "CDO" },
+    { name: "CDC" },
 
-    //ignorables
-    { name: "S", whitespace: true/*, channel: "ws"*/},
+    // ignorables
+    { name: "S", whitespace: true/*, channel: "ws"*/ },
     { name: "COMMENT", comment: true, hide: true, channel: "comment" },
 
-    //attribute equality
-    { name: "INCLUDES", text: "~="},
-    { name: "DASHMATCH", text: "|="},
-    { name: "PREFIXMATCH", text: "^="},
-    { name: "SUFFIXMATCH", text: "$="},
-    { name: "SUBSTRINGMATCH", text: "*="},
+    // attribute equality
+    { name: "INCLUDES", text: "~=" },
+    { name: "DASHMATCH", text: "|=" },
+    { name: "PREFIXMATCH", text: "^=" },
+    { name: "SUFFIXMATCH", text: "$=" },
+    { name: "SUBSTRINGMATCH", text: "*=" },
 
-    //identifier types
-    { name: "STRING"},
-    { name: "IDENT"},
-    { name: "HASH"},
+    // identifier types
+    { name: "STRING" },
+    { name: "IDENT" },
+    { name: "HASH" },
 
-    //at-keywords
-    { name: "IMPORT_SYM", text: "@import"},
-    { name: "PAGE_SYM", text: "@page"},
-    { name: "MEDIA_SYM", text: "@media"},
-    { name: "FONT_FACE_SYM", text: "@font-face"},
-    { name: "CHARSET_SYM", text: "@charset"},
-    { name: "NAMESPACE_SYM", text: "@namespace"},
-    { name: "VIEWPORT_SYM", text: ["@viewport", "@-ms-viewport", "@-o-viewport"]},
-    { name: "DOCUMENT_SYM", text: ["@document", "@-moz-document"]},
+    // at-keywords
+    { name: "IMPORT_SYM", text: "@import" },
+    { name: "PAGE_SYM", text: "@page" },
+    { name: "MEDIA_SYM", text: "@media" },
+    { name: "FONT_FACE_SYM", text: "@font-face" },
+    { name: "CHARSET_SYM", text: "@charset" },
+    { name: "NAMESPACE_SYM", text: "@namespace" },
+    { name: "SUPPORTS_SYM", text: "@supports" },
+    { name: "VIEWPORT_SYM", text: ["@viewport", "@-ms-viewport", "@-o-viewport"] },
+    { name: "DOCUMENT_SYM", text: ["@document", "@-moz-document"] },
     { name: "UNKNOWN_SYM" },
     //{ name: "ATKEYWORD"},
 
-    //CSS3 animations
+    // CSS3 animations
     { name: "KEYFRAMES_SYM", text: [ "@keyframes", "@-webkit-keyframes", "@-moz-keyframes", "@-o-keyframes" ] },
 
-    //important symbol
-    { name: "IMPORTANT_SYM"},
+    // important symbol
+    { name: "IMPORTANT_SYM" },
 
-    //measurements
-    { name: "LENGTH"},
-    { name: "ANGLE"},
-    { name: "TIME"},
-    { name: "FREQ"},
-    { name: "DIMENSION"},
-    { name: "PERCENTAGE"},
-    { name: "NUMBER"},
+    // measurements
+    { name: "LENGTH" },
+    { name: "ANGLE" },
+    { name: "TIME" },
+    { name: "FREQ" },
+    { name: "DIMENSION" },
+    { name: "PERCENTAGE" },
+    { name: "NUMBER" },
 
-    //functions
-    { name: "URI"},
-    { name: "FUNCTION"},
+    // functions
+    { name: "URI" },
+    { name: "FUNCTION" },
 
-    //Unicode ranges
-    { name: "UNICODE_RANGE"},
+    // Unicode ranges
+    { name: "UNICODE_RANGE" },
 
     /*
-     * The following token names are defined in CSS3 Selectors: http://www.w3.org/TR/css3-selectors/#selector-syntax
+     * The following token names are defined in CSS3 Selectors: https://www.w3.org/TR/css3-selectors/#selector-syntax
      */
 
-    //invalid string
-    { name: "INVALID"},
+    // invalid string
+    { name: "INVALID" },
 
-    //combinators
+    // combinators
     { name: "PLUS", text: "+" },
-    { name: "GREATER", text: ">"},
-    { name: "COMMA", text: ","},
-    { name: "TILDE", text: "~"},
+    { name: "GREATER", text: ">" },
+    { name: "COMMA", text: "," },
+    { name: "TILDE", text: "~" },
 
-    //modifier
-    { name: "NOT"},
+    // modifier
+    { name: "NOT" },
 
     /*
      * Defined in CSS3 Paged Media
      */
-    { name: "TOPLEFTCORNER_SYM", text: "@top-left-corner"},
-    { name: "TOPLEFT_SYM", text: "@top-left"},
-    { name: "TOPCENTER_SYM", text: "@top-center"},
-    { name: "TOPRIGHT_SYM", text: "@top-right"},
-    { name: "TOPRIGHTCORNER_SYM", text: "@top-right-corner"},
-    { name: "BOTTOMLEFTCORNER_SYM", text: "@bottom-left-corner"},
-    { name: "BOTTOMLEFT_SYM", text: "@bottom-left"},
-    { name: "BOTTOMCENTER_SYM", text: "@bottom-center"},
-    { name: "BOTTOMRIGHT_SYM", text: "@bottom-right"},
-    { name: "BOTTOMRIGHTCORNER_SYM", text: "@bottom-right-corner"},
-    { name: "LEFTTOP_SYM", text: "@left-top"},
-    { name: "LEFTMIDDLE_SYM", text: "@left-middle"},
-    { name: "LEFTBOTTOM_SYM", text: "@left-bottom"},
-    { name: "RIGHTTOP_SYM", text: "@right-top"},
-    { name: "RIGHTMIDDLE_SYM", text: "@right-middle"},
-    { name: "RIGHTBOTTOM_SYM", text: "@right-bottom"},
+    { name: "TOPLEFTCORNER_SYM", text: "@top-left-corner" },
+    { name: "TOPLEFT_SYM", text: "@top-left" },
+    { name: "TOPCENTER_SYM", text: "@top-center" },
+    { name: "TOPRIGHT_SYM", text: "@top-right" },
+    { name: "TOPRIGHTCORNER_SYM", text: "@top-right-corner" },
+    { name: "BOTTOMLEFTCORNER_SYM", text: "@bottom-left-corner" },
+    { name: "BOTTOMLEFT_SYM", text: "@bottom-left" },
+    { name: "BOTTOMCENTER_SYM", text: "@bottom-center" },
+    { name: "BOTTOMRIGHT_SYM", text: "@bottom-right" },
+    { name: "BOTTOMRIGHTCORNER_SYM", text: "@bottom-right-corner" },
+    { name: "LEFTTOP_SYM", text: "@left-top" },
+    { name: "LEFTMIDDLE_SYM", text: "@left-middle" },
+    { name: "LEFTBOTTOM_SYM", text: "@left-bottom" },
+    { name: "RIGHTTOP_SYM", text: "@right-top" },
+    { name: "RIGHTMIDDLE_SYM", text: "@right-middle" },
+    { name: "RIGHTBOTTOM_SYM", text: "@right-bottom" },
 
     /*
-     * The following token names are defined in CSS3 Media Queries: http://www.w3.org/TR/css3-mediaqueries/#syntax
+     * The following token names are defined in CSS3 Media Queries: https://www.w3.org/TR/css3-mediaqueries/#syntax
      */
     /*{ name: "MEDIA_ONLY", state: "media"},
     { name: "MEDIA_NOT", state: "media"},
     { name: "MEDIA_AND", state: "media"},*/
-    { name: "RESOLUTION", state: "media"},
+    { name: "RESOLUTION", state: "media" },
 
     /*
      * The following token names are not defined in any CSS specification but are used by the lexer.
      */
 
-    //not a real token, but useful for stupid IE filters
+    // not a real token, but useful for stupid IE filters
     { name: "IE_FUNCTION" },
 
-    //part of CSS3 grammar but not the Flex code
+    // part of CSS3 grammar but not the Flex code
     { name: "CHAR" },
 
-    //TODO: Needed?
-    //Not defined as tokens, but might as well be
+    // TODO: Needed?
+    // Not defined as tokens, but might as well be
     {
         name: "PIPE",
         text: "|"
@@ -6029,7 +5746,6 @@ var Tokens  = [
         name: "SEMICOLON",
         text: ";"
     },
-
     {
         name: "LPAREN",
         endChar: ")",
@@ -6045,19 +5761,18 @@ var Tokens  = [
     }
 ];
 
-(function(){
-
+(function() {
     var nameMap = [],
-        typeMap = {};
+        typeMap = Object.create(null);
 
     Tokens.UNKNOWN = -1;
-    Tokens.unshift({name:"EOF"});
-    for (var i=0, len = Tokens.length; i < len; i++){
+    Tokens.unshift({ name:"EOF" });
+    for (var i=0, len = Tokens.length; i < len; i++) {
         nameMap.push(Tokens[i].name);
         Tokens[Tokens[i].name] = i;
-        if (Tokens[i].text){
-            if (Tokens[i].text instanceof Array){
-                for (var j=0; j < Tokens[i].text.length; j++){
+        if (Tokens[i].text) {
+            if (Tokens[i].text instanceof Array) {
+                for (var j=0; j < Tokens[i].text.length; j++) {
                     typeMap[Tokens[i].text[j]] = i;
                 }
             } else {
@@ -6066,186 +5781,88 @@ var Tokens  = [
         }
     }
 
-    Tokens.name = function(tt){
+    Tokens.name = function(tt) {
         return nameMap[tt];
     };
 
-    Tokens.type = function(c){
+    Tokens.type = function(c) {
         return typeMap[c] || -1;
     };
-
 })();
 
+},{}],19:[function(require,module,exports){
+"use strict";
 
+/* exported Validation */
 
+var Matcher = require("./Matcher");
+var Properties = require("./Properties");
+var ValidationTypes = require("./ValidationTypes");
+var ValidationError = require("./ValidationError");
+var PropertyValueIterator = require("./PropertyValueIterator");
 
-//This file will likely change a lot! Very experimental!
-/*global Properties, ValidationTypes, ValidationError, PropertyValueIterator */
-var Validation = {
+var Validation = module.exports = {
 
-    validate: function(property, value){
+    validate: function(property, value) {
 
         //normalize name
         var name        = property.toString().toLowerCase(),
-            parts       = value.parts,
             expression  = new PropertyValueIterator(value),
             spec        = Properties[name],
-            part,
-            valid,
-            j, count,
-            msg,
-            types,
-            last,
-            literals,
-            max, multi, group;
+            part;
 
         if (!spec) {
-            if (name.indexOf("-") !== 0){    //vendor prefixed are ok
+            if (name.indexOf("-") !== 0) {    //vendor prefixed are ok
                 throw new ValidationError("Unknown property '" + property + "'.", property.line, property.col);
             }
-        } else if (typeof spec != "number"){
+        } else if (typeof spec !== "number") {
 
-            //initialization
-            if (typeof spec == "string"){
-                if (spec.indexOf("||") > -1) {
-                    this.groupProperty(spec, expression);
-                } else {
-                    this.singleProperty(spec, expression, 1);
+            // All properties accept some CSS-wide values.
+            // https://drafts.csswg.org/css-values-3/#common-keywords
+            if (ValidationTypes.isAny(expression, "inherit | initial | unset")) {
+                if (expression.hasNext()) {
+                    part = expression.next();
+                    throw new ValidationError("Expected end of value but found '" + part + "'.", part.line, part.col);
                 }
-
-            } else if (spec.multi) {
-                this.multiProperty(spec.multi, expression, spec.comma, spec.max || Infinity);
-            } else if (typeof spec == "function") {
-                spec(expression);
+                return;
             }
+
+            // Property-specific validation.
+            this.singleProperty(spec, expression);
 
         }
 
     },
 
-    singleProperty: function(types, expression, max, partial) {
+    singleProperty: function(types, expression) {
 
         var result      = false,
             value       = expression.value,
-            count       = 0,
             part;
 
-        while (expression.hasNext() && count < max) {
-            result = ValidationTypes.isAny(expression, types);
-            if (!result) {
-                break;
-            }
-            count++;
-        }
+        result = Matcher.parse(types).match(expression);
 
         if (!result) {
             if (expression.hasNext() && !expression.isFirst()) {
                 part = expression.peek();
                 throw new ValidationError("Expected end of value but found '" + part + "'.", part.line, part.col);
             } else {
-                 throw new ValidationError("Expected (" + types + ") but found '" + value + "'.", value.line, value.col);
+                throw new ValidationError("Expected (" + ValidationTypes.describe(types) + ") but found '" + value + "'.", value.line, value.col);
             }
         } else if (expression.hasNext()) {
             part = expression.next();
             throw new ValidationError("Expected end of value but found '" + part + "'.", part.line, part.col);
         }
 
-    },
-
-    multiProperty: function (types, expression, comma, max) {
-
-        var result      = false,
-            value       = expression.value,
-            count       = 0,
-            sep         = false,
-            part;
-
-        while(expression.hasNext() && !result && count < max) {
-            if (ValidationTypes.isAny(expression, types)) {
-                count++;
-                if (!expression.hasNext()) {
-                    result = true;
-
-                } else if (comma) {
-                    if (expression.peek() == ",") {
-                        part = expression.next();
-                    } else {
-                        break;
-                    }
-                }
-            } else {
-                break;
-
-            }
-        }
-
-        if (!result) {
-            if (expression.hasNext() && !expression.isFirst()) {
-                part = expression.peek();
-                throw new ValidationError("Expected end of value but found '" + part + "'.", part.line, part.col);
-            } else {
-                part = expression.previous();
-                if (comma && part == ",") {
-                    throw new ValidationError("Expected end of value but found '" + part + "'.", part.line, part.col);
-                } else {
-                    throw new ValidationError("Expected (" + types + ") but found '" + value + "'.", value.line, value.col);
-                }
-            }
-
-        } else if (expression.hasNext()) {
-            part = expression.next();
-            throw new ValidationError("Expected end of value but found '" + part + "'.", part.line, part.col);
-        }
-
-    },
-
-    groupProperty: function (types, expression, comma) {
-
-        var result      = false,
-            value       = expression.value,
-            typeCount   = types.split("||").length,
-            groups      = { count: 0 },
-            partial     = false,
-            name,
-            part;
-
-        while(expression.hasNext() && !result) {
-            name = ValidationTypes.isAnyOfGroup(expression, types);
-            if (name) {
-
-                //no dupes
-                if (groups[name]) {
-                    break;
-                } else {
-                    groups[name] = 1;
-                    groups.count++;
-                    partial = true;
-
-                    if (groups.count == typeCount || !expression.hasNext()) {
-                        result = true;
-                    }
-                }
-            } else {
-                break;
-            }
-        }
-
-        if (!result) {
-            if (partial && expression.hasNext()) {
-                    part = expression.peek();
-                    throw new ValidationError("Expected end of value but found '" + part + "'.", part.line, part.col);
-            } else {
-                throw new ValidationError("Expected (" + types + ") but found '" + value + "'.", value.line, value.col);
-            }
-        } else if (expression.hasNext()) {
-            part = expression.next();
-            throw new ValidationError("Expected end of value but found '" + part + "'.", part.line, part.col);
-        }
     }
 
-
-
 };
+
+},{"./Matcher":3,"./Properties":7,"./PropertyValueIterator":10,"./ValidationError":20,"./ValidationTypes":21}],20:[function(require,module,exports){
+"use strict";
+
+module.exports = ValidationError;
+
 /**
  * Type to use when a validation error occurs.
  * @class ValidationError
@@ -6255,7 +5872,7 @@ var Validation = {
  * @param {int} line The line at which the error occurred.
  * @param {int} col The column at which the error occurred.
  */
-function ValidationError(message, line, col){
+function ValidationError(message, line, col) {
 
     /**
      * The column at which the error occurred.
@@ -6282,17 +5899,33 @@ function ValidationError(message, line, col){
 
 //inherit from Error
 ValidationError.prototype = new Error();
-//This file will likely change a lot! Very experimental!
-/*global Properties, Validation, ValidationError, PropertyValueIterator, console*/
-var ValidationTypes = {
+
+},{}],21:[function(require,module,exports){
+"use strict";
+
+var ValidationTypes = module.exports;
+
+var Matcher = require("./Matcher");
+
+function copy(to, from) {
+    Object.keys(from).forEach(function(prop) {
+        to[prop] = from[prop];
+    });
+}
+copy(ValidationTypes, {
 
     isLiteral: function (part, literals) {
         var text = part.text.toString().toLowerCase(),
             args = literals.split(" | "),
             i, len, found = false;
 
-        for (i=0,len=args.length; i < len && !found; i++){
-            if (text == args[i].toLowerCase()){
+        for (i=0, len=args.length; i < len && !found; i++) {
+            if (args[i].charAt(0) === "<") {
+                found = this.simple[args[i]](part);
+            } else if (args[i].slice(-2) === "()") {
+                found = (part.type === "function" &&
+                         part.name === args[i].slice(0, -2));
+            } else if (text === args[i].toLowerCase()) {
                 found = true;
             }
         }
@@ -6301,11 +5934,18 @@ var ValidationTypes = {
     },
 
     isSimple: function(type) {
-        return !!this.simple[type];
+        return Boolean(this.simple[type]);
     },
 
     isComplex: function(type) {
-        return !!this.complex[type];
+        return Boolean(this.complex[type]);
+    },
+
+    describe: function(type) {
+        if (this.complex[type] instanceof Matcher) {
+            return this.complex[type].toString(0);
+        }
+        return type;
     },
 
     /**
@@ -6316,7 +5956,7 @@ var ValidationTypes = {
         var args = types.split(" | "),
             i, len, found = false;
 
-        for (i=0,len=args.length; i < len && !found && expression.hasNext(); i++){
+        for (i=0, len=args.length; i < len && !found && expression.hasNext(); i++) {
             found = this.isType(expression, args[i]);
         }
 
@@ -6331,7 +5971,7 @@ var ValidationTypes = {
         var args = types.split(" || "),
             i, len, found = false;
 
-        for (i=0,len=args.length; i < len && !found; i++){
+        for (i=0, len=args.length; i < len && !found; i++) {
             found = this.isType(expression, args[i]);
         }
 
@@ -6346,7 +5986,7 @@ var ValidationTypes = {
         var part = expression.peek(),
             result = false;
 
-        if (type.charAt(0) != "<") {
+        if (type.charAt(0) !== "<") {
             result = this.isLiteral(part, type);
             if (result) {
                 expression.next();
@@ -6356,6 +5996,8 @@ var ValidationTypes = {
             if (result) {
                 expression.next();
             }
+        } else if (this.complex[type] instanceof Matcher) {
+            result = this.complex[type].match(expression);
         } else {
             result = this.complex[type](expression);
         }
@@ -6364,391 +6006,1346 @@ var ValidationTypes = {
     },
 
 
-
     simple: {
+        __proto__: null,
 
-        "<absolute-size>": function(part){
-            return ValidationTypes.isLiteral(part, "xx-small | x-small | small | medium | large | x-large | xx-large");
+        "<absolute-size>":
+            "xx-small | x-small | small | medium | large | x-large | xx-large",
+
+        "<animateable-feature>":
+            "scroll-position | contents | <animateable-feature-name>",
+
+        "<animateable-feature-name>": function(part) {
+            return this["<ident>"](part) &&
+                !/^(unset|initial|inherit|will-change|auto|scroll-position|contents)$/i.test(part);
         },
 
-        "<attachment>": function(part){
-            return ValidationTypes.isLiteral(part, "scroll | fixed | local");
+        "<angle>": function(part) {
+            return part.type === "angle";
         },
 
-        "<attr>": function(part){
-            return part.type == "function" && part.name == "attr";
+        "<attachment>": "scroll | fixed | local",
+
+        "<attr>": "attr()",
+
+        // inset() = inset( <shape-arg>{1,4} [round <border-radius>]? )
+        // circle() = circle( [<shape-radius>]? [at <position>]? )
+        // ellipse() = ellipse( [<shape-radius>{2}]? [at <position>]? )
+        // polygon() = polygon( [<fill-rule>,]? [<shape-arg> <shape-arg>]# )
+        "<basic-shape>": "inset() | circle() | ellipse() | polygon()",
+
+        "<bg-image>": "<image> | <gradient> | none",
+
+        "<border-style>":
+            "none | hidden | dotted | dashed | solid | double | groove | " +
+            "ridge | inset | outset",
+
+        "<border-width>": "<length> | thin | medium | thick",
+
+        "<box>": "padding-box | border-box | content-box",
+
+        "<clip-source>": "<uri>",
+
+        "<color>": function(part) {
+            return part.type === "color" || String(part) === "transparent" || String(part) === "currentColor";
         },
 
-        "<bg-image>": function(part){
-            return this["<image>"](part) || this["<gradient>"](part) ||  part == "none";
+        // The SVG <color> spec doesn't include "currentColor" or "transparent" as a color.
+        "<color-svg>": function(part) {
+            return part.type === "color";
+        },
+
+        "<content>": "content()",
+
+        // https://www.w3.org/TR/css3-sizing/#width-height-keywords
+        "<content-sizing>":
+            "fill-available | -moz-available | -webkit-fill-available | " +
+            "max-content | -moz-max-content | -webkit-max-content | " +
+            "min-content | -moz-min-content | -webkit-min-content | " +
+            "fit-content | -moz-fit-content | -webkit-fit-content",
+
+        "<feature-tag-value>": function(part) {
+            return part.type === "function" && /^[A-Z0-9]{4}$/i.test(part);
+        },
+
+        // custom() isn't actually in the spec
+        "<filter-function>":
+            "blur() | brightness() | contrast() | custom() | " +
+            "drop-shadow() | grayscale() | hue-rotate() | invert() | " +
+            "opacity() | saturate() | sepia()",
+
+        "<flex-basis>": "<width>",
+
+        "<flex-direction>": "row | row-reverse | column | column-reverse",
+
+        "<flex-grow>": "<number>",
+
+        "<flex-shrink>": "<number>",
+
+        "<flex-wrap>": "nowrap | wrap | wrap-reverse",
+
+        "<font-size>":
+            "<absolute-size> | <relative-size> | <length> | <percentage>",
+
+        "<font-stretch>":
+            "normal | ultra-condensed | extra-condensed | condensed | " +
+            "semi-condensed | semi-expanded | expanded | extra-expanded | " +
+            "ultra-expanded",
+
+        "<font-style>": "normal | italic | oblique",
+
+        "<font-variant-caps>":
+            "small-caps | all-small-caps | petite-caps | all-petite-caps | " +
+            "unicase | titling-caps",
+
+        "<font-variant-css21>": "normal | small-caps",
+
+        "<font-weight>":
+            "normal | bold | bolder | lighter | " +
+            "100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900",
+
+        "<generic-family>":
+            "serif | sans-serif | cursive | fantasy | monospace",
+
+        "<geometry-box>": "<shape-box> | fill-box | stroke-box | view-box",
+
+        "<glyph-angle>": function(part) {
+            return part.type === "angle" && part.units === "deg";
         },
 
         "<gradient>": function(part) {
-            return part.type == "function" && /^(?:\-(?:ms|moz|o|webkit)\-)?(?:repeating\-)?(?:radial\-|linear\-)?gradient/i.test(part);
+            return part.type === "function" && /^(?:\-(?:ms|moz|o|webkit)\-)?(?:repeating\-)?(?:radial\-|linear\-)?gradient/i.test(part);
         },
 
-        "<box>": function(part){
-            return ValidationTypes.isLiteral(part, "padding-box | border-box | content-box");
-        },
-
-        "<content>": function(part){
-            return part.type == "function" && part.name == "content";
-        },
-
-        "<relative-size>": function(part){
-            return ValidationTypes.isLiteral(part, "smaller | larger");
-        },
+        "<icccolor>":
+            "cielab() | cielch() | cielchab() | " +
+            "icc-color() | icc-named-color()",
 
         //any identifier
-        "<ident>": function(part){
-            return part.type == "identifier";
+        "<ident>": function(part) {
+            return part.type === "identifier" || part.wasIdent;
         },
 
-        "<length>": function(part){
-            if (part.type == "function" && /^(?:\-(?:ms|moz|o|webkit)\-)?calc/i.test(part)){
+        "<ident-not-generic-family>": function(part) {
+            return this["<ident>"](part) && !this["<generic-family>"](part);
+        },
+
+        "<image>": "<uri>",
+
+        "<integer>": function(part) {
+            return part.type === "integer";
+        },
+
+        "<length>": function(part) {
+            if (part.type === "function" && /^(?:\-(?:ms|moz|o|webkit)\-)?calc/i.test(part)) {
                 return true;
-            }else{
-                return part.type == "length" || part.type == "number" || part.type == "integer" || part == "0";
+            } else {
+                return part.type === "length" || part.type === "number" || part.type === "integer" || String(part) === "0";
             }
         },
 
-        "<color>": function(part){
-            return part.type == "color" || part == "transparent" || part == "currentColor";
+        "<line>": function(part) {
+            return part.type === "integer";
         },
 
-        "<number>": function(part){
-            return part.type == "number" || this["<integer>"](part);
+        "<line-height>": "<number> | <length> | <percentage> | normal",
+
+        "<margin-width>": "<length> | <percentage> | auto",
+
+        "<miterlimit>": function(part) {
+            return this["<number>"](part) && part.value >= 1;
         },
 
-        "<integer>": function(part){
-            return part.type == "integer";
+        "<nonnegative-length-or-percentage>": function(part) {
+            return (this["<length>"](part) || this["<percentage>"](part)) &&
+                (String(part) === "0" || part.type === "function" || (part.value) >= 0);
         },
 
-        "<line>": function(part){
-            return part.type == "integer";
+        "<nonnegative-number-or-percentage>": function(part) {
+            return (this["<number>"](part) || this["<percentage>"](part)) &&
+                (String(part) === "0" || part.type === "function" || (part.value) >= 0);
         },
 
-        "<angle>": function(part){
-            return part.type == "angle";
+        "<number>": function(part) {
+            return part.type === "number" || this["<integer>"](part);
         },
 
-        "<uri>": function(part){
-            return part.type == "uri";
+        "<opacity-value>": function(part) {
+            return this["<number>"](part) && part.value >= 0 && part.value <= 1;
         },
 
-        "<image>": function(part){
-            return this["<uri>"](part);
+        "<padding-width>": "<nonnegative-length-or-percentage>",
+
+        "<percentage>": function(part) {
+            return part.type === "percentage" || String(part) === "0";
         },
 
-        "<percentage>": function(part){
-            return part.type == "percentage" || part == "0";
+        "<relative-size>": "smaller | larger",
+
+        "<shape>": "rect() | inset-rect()",
+
+        "<shape-box>": "<box> | margin-box",
+
+        "<single-animation-direction>":
+            "normal | reverse | alternate | alternate-reverse",
+
+        "<single-animation-name>": function(part) {
+            return this["<ident>"](part) &&
+                /^-?[a-z_][-a-z0-9_]+$/i.test(part) &&
+                !/^(none|unset|initial|inherit)$/i.test(part);
         },
 
-        "<border-width>": function(part){
-            return this["<length>"](part) || ValidationTypes.isLiteral(part, "thin | medium | thick");
-        },
-
-        "<border-style>": function(part){
-            return ValidationTypes.isLiteral(part, "none | hidden | dotted | dashed | solid | double | groove | ridge | inset | outset");
-        },
-
-        "<content-sizing>": function(part){ // http://www.w3.org/TR/css3-sizing/#width-height-keywords
-            return ValidationTypes.isLiteral(part, "fill-available | -moz-available | -webkit-fill-available | max-content | -moz-max-content | -webkit-max-content | min-content | -moz-min-content | -webkit-min-content | fit-content | -moz-fit-content | -webkit-fit-content");
-        },
-
-        "<margin-width>": function(part){
-            return this["<length>"](part) || this["<percentage>"](part) || ValidationTypes.isLiteral(part, "auto");
-        },
-
-        "<padding-width>": function(part){
-            return this["<length>"](part) || this["<percentage>"](part);
-        },
-
-        "<shape>": function(part){
-            return part.type == "function" && (part.name == "rect" || part.name == "inset-rect");
+        "<string>": function(part) {
+            return part.type === "string";
         },
 
         "<time>": function(part) {
-            return part.type == "time";
+            return part.type === "time";
         },
 
-        "<flex-grow>": function(part){
-            return this["<number>"](part);
+        "<uri>": function(part) {
+            return part.type === "uri";
         },
 
-        "<flex-shrink>": function(part){
-            return this["<number>"](part);
-        },
-
-        "<width>": function(part){
-            return this["<margin-width>"](part);
-        },
-
-        "<flex-basis>": function(part){
-            return this["<width>"](part);
-        },
-
-        "<flex-direction>": function(part){
-            return ValidationTypes.isLiteral(part, "row | row-reverse | column | column-reverse");
-        },
-
-        "<flex-wrap>": function(part){
-            return ValidationTypes.isLiteral(part, "nowrap | wrap | wrap-reverse");
-        },
-
-        "<feature-tag-value>": function(part){
-            return (part.type == "function" && /^[A-Z0-9]{4}$/i.test(part));
-        }
+        "<width>": "<margin-width>"
     },
 
     complex: {
+        __proto__: null,
 
-        "<bg-position>": function(expression){
-            var types   = this,
-                result  = false,
-                numeric = "<percentage> | <length>",
-                xDir    = "left | right",
-                yDir    = "top | bottom",
-                count = 0,
-                hasNext = function() {
-                    return expression.hasNext() && expression.peek() != ",";
-                };
+        "<azimuth>":
+            "<angle>" +
+            " | " +
+            "[ [ left-side | far-left | left | center-left | center | " +
+            "center-right | right | far-right | right-side ] || behind ]" +
+            " | "+
+            "leftwards | rightwards",
 
-            while (expression.peek(count) && expression.peek(count) != ",") {
-                count++;
-            }
+        "<bg-position>": "<position>#",
 
-/*
-<position> = [
-  [ left | center | right | top | bottom | <percentage> | <length> ]
-|
-  [ left | center | right | <percentage> | <length> ]
-  [ top | center | bottom | <percentage> | <length> ]
-|
-  [ center | [ left | right ] [ <percentage> | <length> ]? ] &&
-  [ center | [ top | bottom ] [ <percentage> | <length> ]? ]
-]
-*/
+        "<bg-size>":
+            "[ <length> | <percentage> | auto ]{1,2} | cover | contain",
 
-            if (count < 3) {
-                if (ValidationTypes.isAny(expression, xDir + " | center | " + numeric)) {
-                        result = true;
-                        ValidationTypes.isAny(expression, yDir + " | center | " + numeric);
-                } else if (ValidationTypes.isAny(expression, yDir)) {
-                        result = true;
-                        ValidationTypes.isAny(expression, xDir + " | center");
-                }
-            } else {
-                if (ValidationTypes.isAny(expression, xDir)) {
-                    if (ValidationTypes.isAny(expression, yDir)) {
-                        result = true;
-                        ValidationTypes.isAny(expression, numeric);
-                    } else if (ValidationTypes.isAny(expression, numeric)) {
-                        if (ValidationTypes.isAny(expression, yDir)) {
-                            result = true;
-                            ValidationTypes.isAny(expression, numeric);
-                        } else if (ValidationTypes.isAny(expression, "center")) {
-                            result = true;
-                        }
-                    }
-                } else if (ValidationTypes.isAny(expression, yDir)) {
-                    if (ValidationTypes.isAny(expression, xDir)) {
-                        result = true;
-                        ValidationTypes.isAny(expression, numeric);
-                    } else if (ValidationTypes.isAny(expression, numeric)) {
-                        if (ValidationTypes.isAny(expression, xDir)) {
-                                result = true;
-                                ValidationTypes.isAny(expression, numeric);
-                        } else if (ValidationTypes.isAny(expression, "center")) {
-                            result = true;
-                        }
-                    }
-                } else if (ValidationTypes.isAny(expression, "center")) {
-                    if (ValidationTypes.isAny(expression, xDir + " | " + yDir)) {
-                        result = true;
-                        ValidationTypes.isAny(expression, numeric);
-                    }
-                }
-            }
+        "<border-image-slice>":
+        // [<number> | <percentage>]{1,4} && fill?
+        // *but* fill can appear between any of the numbers
+        Matcher.many([true /* first element is required */],
+                     Matcher.cast("<nonnegative-number-or-percentage>"),
+                     Matcher.cast("<nonnegative-number-or-percentage>"),
+                     Matcher.cast("<nonnegative-number-or-percentage>"),
+                     Matcher.cast("<nonnegative-number-or-percentage>"),
+                     "fill"),
 
-            return result;
-        },
+        "<border-radius>":
+            "<nonnegative-length-or-percentage>{1,4} " +
+            "[ / <nonnegative-length-or-percentage>{1,4} ]?",
 
-        "<bg-size>": function(expression){
-            //<bg-size> = [ <length> | <percentage> | auto ]{1,2} | cover | contain
-            var types   = this,
-                result  = false,
-                numeric = "<percentage> | <length> | auto",
-                part,
-                i, len;
+        "<box-shadow>": "none | <shadow>#",
 
-            if (ValidationTypes.isAny(expression, "cover | contain")) {
-                result = true;
-            } else if (ValidationTypes.isAny(expression, numeric)) {
-                result = true;
-                ValidationTypes.isAny(expression, numeric);
-            }
+        "<clip-path>": "<basic-shape> || <geometry-box>",
 
-            return result;
-        },
+        "<dasharray>":
+        // "list of comma and/or white space separated <length>s and
+        // <percentage>s".  There is a non-negative constraint.
+        Matcher.cast("<nonnegative-length-or-percentage>")
+            .braces(1, Infinity, "#", Matcher.cast(",").question()),
 
-        "<repeat-style>": function(expression){
-            //repeat-x | repeat-y | [repeat | space | round | no-repeat]{1,2}
-            var result  = false,
-                values  = "repeat | space | round | no-repeat",
-                part;
+        "<family-name>":
+            // <string> | <IDENT>+
+            "<string> | <ident-not-generic-family> <ident>*",
 
-            if (expression.hasNext()){
-                part = expression.next();
+        "<filter-function-list>": "[ <filter-function> | <uri> ]+",
 
-                if (ValidationTypes.isLiteral(part, "repeat-x | repeat-y")) {
-                    result = true;
-                } else if (ValidationTypes.isLiteral(part, values)) {
-                    result = true;
+        // https://www.w3.org/TR/2014/WD-css-flexbox-1-20140325/#flex-property
+        "<flex>":
+            "none | [ <flex-grow> <flex-shrink>? || <flex-basis> ]",
 
-                    if (expression.hasNext() && ValidationTypes.isLiteral(expression.peek(), values)) {
-                        expression.next();
-                    }
-                }
-            }
+        "<font-family>": "[ <generic-family> | <family-name> ]#",
 
-            return result;
+        "<font-shorthand>":
+            "[ <font-style> || <font-variant-css21> || " +
+            "<font-weight> || <font-stretch> ]? <font-size> " +
+            "[ / <line-height> ]? <font-family>",
 
-        },
+        "<font-variant-alternates>":
+            // stylistic(<feature-value-name>)
+            "stylistic() || " +
+            "historical-forms || " +
+            // styleset(<feature-value-name> #)
+            "styleset() || " +
+            // character-variant(<feature-value-name> #)
+            "character-variant() || " +
+            // swash(<feature-value-name>)
+            "swash() || " +
+            // ornaments(<feature-value-name>)
+            "ornaments() || " +
+            // annotation(<feature-value-name>)
+            "annotation()",
 
-        "<shadow>": function(expression) {
-            //inset? && [ <length>{2,4} && <color>? ]
-            var result  = false,
-                count   = 0,
-                inset   = false,
-                color   = false,
-                part;
+        "<font-variant-ligatures>":
+            // <common-lig-values>
+            "[ common-ligatures | no-common-ligatures ] || " +
+            // <discretionary-lig-values>
+            "[ discretionary-ligatures | no-discretionary-ligatures ] || " +
+            // <historical-lig-values>
+            "[ historical-ligatures | no-historical-ligatures ] || " +
+            // <contextual-alt-values>
+            "[ contextual | no-contextual ]",
 
-            if (expression.hasNext()) {
+        "<font-variant-numeric>":
+            // <numeric-figure-values>
+            "[ lining-nums | oldstyle-nums ] || " +
+            // <numeric-spacing-values>
+            "[ proportional-nums | tabular-nums ] || " +
+            // <numeric-fraction-values>
+            "[ diagonal-fractions | stacked-fractions ] || " +
+            "ordinal || slashed-zero",
 
-                if (ValidationTypes.isAny(expression, "inset")){
-                    inset = true;
-                }
+        "<font-variant-east-asian>":
+            // <east-asian-variant-values>
+            "[ jis78 | jis83 | jis90 | jis04 | simplified | traditional ] || " +
+            // <east-asian-width-values>
+            "[ full-width | proportional-width ] || " +
+            "ruby",
 
-                if (ValidationTypes.isAny(expression, "<color>")) {
-                    color = true;
-                }
+        // Note that <color> here is "as defined in the SVG spec", which
+        // is more restrictive that the <color> defined in the CSS spec.
+        // none | currentColor | <color> [<icccolor>]? |
+        // <funciri> [ none | currentColor | <color> [<icccolor>]? ]?
+        "<paint>": "<paint-basic> | <uri> <paint-basic>?",
 
-                while (ValidationTypes.isAny(expression, "<length>") && count < 4) {
-                    count++;
-                }
+        // Helper definition for <paint> above.
+        "<paint-basic>": "none | currentColor | <color-svg> <icccolor>?",
 
+        "<position>":
+            // Because our `alt` combinator is ordered, we need to test these
+            // in order from longest possible match to shortest.
+            "[ center | [ left | right ] [ <percentage> | <length> ]? ] && " +
+            "[ center | [ top | bottom ] [ <percentage> | <length> ]? ]" +
+            " | " +
+            "[ left | center | right | <percentage> | <length> ] " +
+            "[ top | center | bottom | <percentage> | <length> ]" +
+            " | " +
+            "[ left | center | right | top | bottom | <percentage> | <length> ]",
 
-                if (expression.hasNext()) {
-                    if (!color) {
-                        ValidationTypes.isAny(expression, "<color>");
-                    }
+        "<repeat-style>":
+            "repeat-x | repeat-y | [ repeat | space | round | no-repeat ]{1,2}",
 
-                    if (!inset) {
-                        ValidationTypes.isAny(expression, "inset");
-                    }
+        "<shadow>":
+        //inset? && [ <length>{2,4} && <color>? ]
+        Matcher.many([true /* length is required */],
+                     Matcher.cast("<length>").braces(2, 4), "inset", "<color>"),
 
-                }
+        "<text-decoration-color>":
+           "<color>",
 
-                result = (count >= 2 && count <= 4);
+        "<text-decoration-line>":
+            "none | [ underline || overline || line-through || blink ]",
 
-            }
+        "<text-decoration-style>":
+            "solid | double | dotted | dashed | wavy",
 
-            return result;
-        },
+        "<will-change>":
+            "auto | <animateable-feature>#",
 
-        "<x-one-radius>": function(expression) {
+        "<x-one-radius>":
             //[ <length> | <percentage> ] [ <length> | <percentage> ]?
-            var result  = false,
-                simple = "<length> | <percentage> | inherit";
+            "[ <length> | <percentage> ]{1,2}"
+    }
+});
 
-            if (ValidationTypes.isAny(expression, simple)){
-                result = true;
-                ValidationTypes.isAny(expression, simple);
+Object.keys(ValidationTypes.simple).forEach(function(nt) {
+    var rule = ValidationTypes.simple[nt];
+    if (typeof rule === "string") {
+        ValidationTypes.simple[nt] = function(part) {
+            return ValidationTypes.isLiteral(part, rule);
+        };
+    }
+});
+
+Object.keys(ValidationTypes.complex).forEach(function(nt) {
+    var rule = ValidationTypes.complex[nt];
+    if (typeof rule === "string") {
+        ValidationTypes.complex[nt] = Matcher.parse(rule);
+    }
+});
+
+// Because this is defined relative to other complex validation types,
+// we need to define it *after* the rest of the types are initialized.
+ValidationTypes.complex["<font-variant>"] =
+    Matcher.oror({ expand: "<font-variant-ligatures>" },
+                 { expand: "<font-variant-alternates>" },
+                 "<font-variant-caps>",
+                 { expand: "<font-variant-numeric>" },
+                 { expand: "<font-variant-east-asian>" });
+
+},{"./Matcher":3}],22:[function(require,module,exports){
+"use strict";
+
+module.exports = {
+    Colors            : require("./Colors"),
+    Combinator        : require("./Combinator"),
+    Parser            : require("./Parser"),
+    PropertyName      : require("./PropertyName"),
+    PropertyValue     : require("./PropertyValue"),
+    PropertyValuePart : require("./PropertyValuePart"),
+    Matcher           : require("./Matcher"),
+    MediaFeature      : require("./MediaFeature"),
+    MediaQuery        : require("./MediaQuery"),
+    Selector          : require("./Selector"),
+    SelectorPart      : require("./SelectorPart"),
+    SelectorSubPart   : require("./SelectorSubPart"),
+    Specificity       : require("./Specificity"),
+    TokenStream       : require("./TokenStream"),
+    Tokens            : require("./Tokens"),
+    ValidationError   : require("./ValidationError")
+};
+
+},{"./Colors":1,"./Combinator":2,"./Matcher":3,"./MediaFeature":4,"./MediaQuery":5,"./Parser":6,"./PropertyName":8,"./PropertyValue":9,"./PropertyValuePart":11,"./Selector":13,"./SelectorPart":14,"./SelectorSubPart":15,"./Specificity":16,"./TokenStream":17,"./Tokens":18,"./ValidationError":20}],23:[function(require,module,exports){
+"use strict";
+
+module.exports = EventTarget;
+
+/**
+ * A generic base to inherit from for any object
+ * that needs event handling.
+ * @class EventTarget
+ * @constructor
+ */
+function EventTarget() {
+
+    /**
+     * The array of listeners for various events.
+     * @type Object
+     * @property _listeners
+     * @private
+     */
+    this._listeners = Object.create(null);
+}
+
+EventTarget.prototype = {
+
+    //restore constructor
+    constructor: EventTarget,
+
+    /**
+     * Adds a listener for a given event type.
+     * @param {String} type The type of event to add a listener for.
+     * @param {Function} listener The function to call when the event occurs.
+     * @return {void}
+     * @method addListener
+     */
+    addListener: function(type, listener) {
+        if (!this._listeners[type]) {
+            this._listeners[type] = [];
+        }
+
+        this._listeners[type].push(listener);
+    },
+
+    /**
+     * Fires an event based on the passed-in object.
+     * @param {Object|String} event An object with at least a 'type' attribute
+     *      or a string indicating the event name.
+     * @return {void}
+     * @method fire
+     */
+    fire: function(event) {
+        if (typeof event === "string") {
+            event = { type: event };
+        }
+        if (typeof event.target !== "undefined") {
+            event.target = this;
+        }
+
+        if (typeof event.type === "undefined") {
+            throw new Error("Event object missing 'type' property.");
+        }
+
+        if (this._listeners[event.type]) {
+
+            //create a copy of the array and use that so listeners can't chane
+            var listeners = this._listeners[event.type].concat();
+            for (var i=0, len=listeners.length; i < len; i++) {
+                listeners[i].call(this, event);
             }
+        }
+    },
 
-            return result;
-        },
-
-        "<flex>": function(expression) {
-            // http://www.w3.org/TR/2014/WD-css-flexbox-1-20140325/#flex-property
-            // none | [ <flex-grow> <flex-shrink>? || <flex-basis> ]
-            // Valid syntaxes, according to https://developer.mozilla.org/en-US/docs/Web/CSS/flex#Syntax
-            // * none
-            // * <flex-grow>
-            // * <flex-basis>
-            // * <flex-grow> <flex-basis>
-            // * <flex-grow> <flex-shrink>
-            // * <flex-grow> <flex-shrink> <flex-basis>
-            // * inherit
-            var part,
-                result = false;
-            if (ValidationTypes.isAny(expression, "none | inherit")) {
-                result = true;
-            } else {
-                if (ValidationTypes.isType(expression, "<flex-grow>")) {
-                    if (expression.peek()) {
-                        if (ValidationTypes.isType(expression, "<flex-shrink>")) {
-                            if (expression.peek()) {
-                                result = ValidationTypes.isType(expression, "<flex-basis>");
-                            } else {
-                                result = true;
-                            }
-                        } else if (ValidationTypes.isType(expression, "<flex-basis>")) {
-                            result = expression.peek() === null;
-                        }
-                    } else {
-                        result = true;
-                    }
-                } else if (ValidationTypes.isType(expression, "<flex-basis>")) {
-                    result = true;
+    /**
+     * Removes a listener for a given event type.
+     * @param {String} type The type of event to remove a listener from.
+     * @param {Function} listener The function to remove from the event.
+     * @return {void}
+     * @method removeListener
+     */
+    removeListener: function(type, listener) {
+        if (this._listeners[type]) {
+            var listeners = this._listeners[type];
+            for (var i=0, len=listeners.length; i < len; i++) {
+                if (listeners[i] === listener) {
+                    listeners.splice(i, 1);
+                    break;
                 }
             }
 
-            if (!result) {
-                // Generate a more verbose error than "Expected <flex>..."
-                part = expression.peek();
-                throw new ValidationError("Expected (none | [ <flex-grow> <flex-shrink>? || <flex-basis> ]) but found '" + expression.value.text + "'.", part.line, part.col);
-            }
 
-            return result;
         }
     }
 };
 
+},{}],24:[function(require,module,exports){
+"use strict";
+
+module.exports = StringReader;
+
+/**
+ * Convenient way to read through strings.
+ * @namespace parserlib.util
+ * @class StringReader
+ * @constructor
+ * @param {String} text The text to read.
+ */
+function StringReader(text) {
+
+    /**
+     * The input text with line endings normalized.
+     * @property _input
+     * @type String
+     * @private
+     */
+    this._input = text.replace(/(\r\n?|\n)/g, "\n");
 
 
-parserlib.css = {
-Colors              :Colors,
-Combinator          :Combinator,
-Parser              :Parser,
-PropertyName        :PropertyName,
-PropertyValue       :PropertyValue,
-PropertyValuePart   :PropertyValuePart,
-MediaFeature        :MediaFeature,
-MediaQuery          :MediaQuery,
-Selector            :Selector,
-SelectorPart        :SelectorPart,
-SelectorSubPart     :SelectorSubPart,
-Specificity         :Specificity,
-TokenStream         :TokenStream,
-Tokens              :Tokens,
-ValidationError     :ValidationError
-};
-})();
+    /**
+     * The row for the character to be read next.
+     * @property _line
+     * @type int
+     * @private
+     */
+    this._line = 1;
 
 
+    /**
+     * The column for the character to be read next.
+     * @property _col
+     * @type int
+     * @private
+     */
+    this._col = 1;
 
-
-(function(){
-for(var prop in parserlib){
-exports[prop] = parserlib[prop];
+    /**
+     * The index of the character in the input to be read next.
+     * @property _cursor
+     * @type int
+     * @private
+     */
+    this._cursor = 0;
 }
+
+StringReader.prototype = {
+
+    // restore constructor
+    constructor: StringReader,
+
+    //-------------------------------------------------------------------------
+    // Position info
+    //-------------------------------------------------------------------------
+
+    /**
+     * Returns the column of the character to be read next.
+     * @return {int} The column of the character to be read next.
+     * @method getCol
+     */
+    getCol: function() {
+        return this._col;
+    },
+
+    /**
+     * Returns the row of the character to be read next.
+     * @return {int} The row of the character to be read next.
+     * @method getLine
+     */
+    getLine: function() {
+        return this._line;
+    },
+
+    /**
+     * Determines if you're at the end of the input.
+     * @return {Boolean} True if there's no more input, false otherwise.
+     * @method eof
+     */
+    eof: function() {
+        return this._cursor === this._input.length;
+    },
+
+    //-------------------------------------------------------------------------
+    // Basic reading
+    //-------------------------------------------------------------------------
+
+    /**
+     * Reads the next character without advancing the cursor.
+     * @param {int} count How many characters to look ahead (default is 1).
+     * @return {String} The next character or null if there is no next character.
+     * @method peek
+     */
+    peek: function(count) {
+        var c = null;
+        count = typeof count === "undefined" ? 1 : count;
+
+        // if we're not at the end of the input...
+        if (this._cursor < this._input.length) {
+
+            // get character and increment cursor and column
+            c = this._input.charAt(this._cursor + count - 1);
+        }
+
+        return c;
+    },
+
+    /**
+     * Reads the next character from the input and adjusts the row and column
+     * accordingly.
+     * @return {String} The next character or null if there is no next character.
+     * @method read
+     */
+    read: function() {
+        var c = null;
+
+        // if we're not at the end of the input...
+        if (this._cursor < this._input.length) {
+
+            // if the last character was a newline, increment row count
+            // and reset column count
+            if (this._input.charAt(this._cursor) === "\n") {
+                this._line++;
+                this._col=1;
+            } else {
+                this._col++;
+            }
+
+            // get character and increment cursor and column
+            c = this._input.charAt(this._cursor++);
+        }
+
+        return c;
+    },
+
+    //-------------------------------------------------------------------------
+    // Misc
+    //-------------------------------------------------------------------------
+
+    /**
+     * Saves the current location so it can be returned to later.
+     * @method mark
+     * @return {void}
+     */
+    mark: function() {
+        this._bookmark = {
+            cursor: this._cursor,
+            line:   this._line,
+            col:    this._col
+        };
+    },
+
+    reset: function() {
+        if (this._bookmark) {
+            this._cursor = this._bookmark.cursor;
+            this._line = this._bookmark.line;
+            this._col = this._bookmark.col;
+            delete this._bookmark;
+        }
+    },
+
+    //-------------------------------------------------------------------------
+    // Advanced reading
+    //-------------------------------------------------------------------------
+
+    /**
+     * Reads up to and including the given string. Throws an error if that
+     * string is not found.
+     * @param {String} pattern The string to read.
+     * @return {String} The string when it is found.
+     * @throws Error when the string pattern is not found.
+     * @method readTo
+     */
+    readTo: function(pattern) {
+
+        var buffer = "",
+            c;
+
+        /*
+         * First, buffer must be the same length as the pattern.
+         * Then, buffer must end with the pattern or else reach the
+         * end of the input.
+         */
+        while (buffer.length < pattern.length || buffer.lastIndexOf(pattern) !== buffer.length - pattern.length) {
+            c = this.read();
+            if (c) {
+                buffer += c;
+            } else {
+                throw new Error("Expected \"" + pattern + "\" at line " + this._line  + ", col " + this._col + ".");
+            }
+        }
+
+        return buffer;
+
+    },
+
+    /**
+     * Reads characters while each character causes the given
+     * filter function to return true. The function is passed
+     * in each character and either returns true to continue
+     * reading or false to stop.
+     * @param {Function} filter The function to read on each character.
+     * @return {String} The string made up of all characters that passed the
+     *      filter check.
+     * @method readWhile
+     */
+    readWhile: function(filter) {
+
+        var buffer = "",
+            c = this.peek();
+
+        while (c !== null && filter(c)) {
+            buffer += this.read();
+            c = this.peek();
+        }
+
+        return buffer;
+
+    },
+
+    /**
+     * Reads characters that match either text or a regular expression and
+     * returns those characters. If a match is found, the row and column
+     * are adjusted; if no match is found, the reader's state is unchanged.
+     * reading or false to stop.
+     * @param {String|RegExp} matcher If a string, then the literal string
+     *      value is searched for. If a regular expression, then any string
+     *      matching the pattern is search for.
+     * @return {String} The string made up of all characters that matched or
+     *      null if there was no match.
+     * @method readMatch
+     */
+    readMatch: function(matcher) {
+
+        var source = this._input.substring(this._cursor),
+            value = null;
+
+        // if it's a string, just do a straight match
+        if (typeof matcher === "string") {
+            if (source.slice(0, matcher.length) === matcher) {
+                value = this.readCount(matcher.length);
+            }
+        } else if (matcher instanceof RegExp) {
+            if (matcher.test(source)) {
+                value = this.readCount(RegExp.lastMatch.length);
+            }
+        }
+
+        return value;
+    },
+
+
+    /**
+     * Reads a given number of characters. If the end of the input is reached,
+     * it reads only the remaining characters and does not throw an error.
+     * @param {int} count The number of characters to read.
+     * @return {String} The string made up the read characters.
+     * @method readCount
+     */
+    readCount: function(count) {
+        var buffer = "";
+
+        while (count--) {
+            buffer += this.read();
+        }
+
+        return buffer;
+    }
+
+};
+
+},{}],25:[function(require,module,exports){
+"use strict";
+
+module.exports = SyntaxError;
+
+/**
+ * Type to use when a syntax error occurs.
+ * @class SyntaxError
+ * @namespace parserlib.util
+ * @constructor
+ * @param {String} message The error message.
+ * @param {int} line The line at which the error occurred.
+ * @param {int} col The column at which the error occurred.
+ */
+function SyntaxError(message, line, col) {
+    Error.call(this);
+    this.name = this.constructor.name;
+
+    /**
+     * The column at which the error occurred.
+     * @type int
+     * @property col
+     */
+    this.col = col;
+
+    /**
+     * The line at which the error occurred.
+     * @type int
+     * @property line
+     */
+    this.line = line;
+
+    /**
+     * The text representation of the unit.
+     * @type String
+     * @property text
+     */
+    this.message = message;
+
+}
+
+//inherit from Error
+SyntaxError.prototype = Object.create(Error.prototype); // jshint ignore:line
+SyntaxError.prototype.constructor = SyntaxError; // jshint ignore:line
+
+},{}],26:[function(require,module,exports){
+"use strict";
+
+module.exports = SyntaxUnit;
+
+/**
+ * Base type to represent a single syntactic unit.
+ * @class SyntaxUnit
+ * @namespace parserlib.util
+ * @constructor
+ * @param {String} text The text of the unit.
+ * @param {int} line The line of text on which the unit resides.
+ * @param {int} col The column of text on which the unit resides.
+ */
+function SyntaxUnit(text, line, col, type) {
+
+
+    /**
+     * The column of text on which the unit resides.
+     * @type int
+     * @property col
+     */
+    this.col = col;
+
+    /**
+     * The line of text on which the unit resides.
+     * @type int
+     * @property line
+     */
+    this.line = line;
+
+    /**
+     * The text representation of the unit.
+     * @type String
+     * @property text
+     */
+    this.text = text;
+
+    /**
+     * The type of syntax unit.
+     * @type int
+     * @property type
+     */
+    this.type = type;
+}
+
+/**
+ * Create a new syntax unit based solely on the given token.
+ * Convenience method for creating a new syntax unit when
+ * it represents a single token instead of multiple.
+ * @param {Object} token The token object to represent.
+ * @return {parserlib.util.SyntaxUnit} The object representing the token.
+ * @static
+ * @method fromToken
+ */
+SyntaxUnit.fromToken = function(token) {
+    return new SyntaxUnit(token.value, token.startLine, token.startCol);
+};
+
+SyntaxUnit.prototype = {
+
+    //restore constructor
+    constructor: SyntaxUnit,
+
+    /**
+     * Returns the text representation of the unit.
+     * @return {String} The text representation of the unit.
+     * @method valueOf
+     */
+    valueOf: function() {
+        return this.toString();
+    },
+
+    /**
+     * Returns the text representation of the unit.
+     * @return {String} The text representation of the unit.
+     * @method toString
+     */
+    toString: function() {
+        return this.text;
+    }
+
+};
+
+},{}],27:[function(require,module,exports){
+"use strict";
+
+module.exports = TokenStreamBase;
+
+var StringReader = require("./StringReader");
+var SyntaxError = require("./SyntaxError");
+
+/**
+ * Generic TokenStream providing base functionality.
+ * @class TokenStreamBase
+ * @namespace parserlib.util
+ * @constructor
+ * @param {String|StringReader} input The text to tokenize or a reader from
+ *      which to read the input.
+ */
+function TokenStreamBase(input, tokenData) {
+
+    /**
+     * The string reader for easy access to the text.
+     * @type StringReader
+     * @property _reader
+     * @private
+     */
+    this._reader = new StringReader(input ? input.toString() : "");
+
+    /**
+     * Token object for the last consumed token.
+     * @type Token
+     * @property _token
+     * @private
+     */
+    this._token = null;
+
+    /**
+     * The array of token information.
+     * @type Array
+     * @property _tokenData
+     * @private
+     */
+    this._tokenData = tokenData;
+
+    /**
+     * Lookahead token buffer.
+     * @type Array
+     * @property _lt
+     * @private
+     */
+    this._lt = [];
+
+    /**
+     * Lookahead token buffer index.
+     * @type int
+     * @property _ltIndex
+     * @private
+     */
+    this._ltIndex = 0;
+
+    this._ltIndexCache = [];
+}
+
+/**
+ * Accepts an array of token information and outputs
+ * an array of token data containing key-value mappings
+ * and matching functions that the TokenStream needs.
+ * @param {Array} tokens An array of token descriptors.
+ * @return {Array} An array of processed token data.
+ * @method createTokenData
+ * @static
+ */
+TokenStreamBase.createTokenData = function(tokens) {
+
+    var nameMap     = [],
+        typeMap     = Object.create(null),
+        tokenData     = tokens.concat([]),
+        i            = 0,
+        len            = tokenData.length+1;
+
+    tokenData.UNKNOWN = -1;
+    tokenData.unshift({ name:"EOF" });
+
+    for (; i < len; i++) {
+        nameMap.push(tokenData[i].name);
+        tokenData[tokenData[i].name] = i;
+        if (tokenData[i].text) {
+            typeMap[tokenData[i].text] = i;
+        }
+    }
+
+    tokenData.name = function(tt) {
+        return nameMap[tt];
+    };
+
+    tokenData.type = function(c) {
+        return typeMap[c];
+    };
+
+    return tokenData;
+};
+
+TokenStreamBase.prototype = {
+
+    //restore constructor
+    constructor: TokenStreamBase,
+
+    //-------------------------------------------------------------------------
+    // Matching methods
+    //-------------------------------------------------------------------------
+
+    /**
+     * Determines if the next token matches the given token type.
+     * If so, that token is consumed; if not, the token is placed
+     * back onto the token stream. You can pass in any number of
+     * token types and this will return true if any of the token
+     * types is found.
+     * @param {int|int[]} tokenTypes Either a single token type or an array of
+     *      token types that the next token might be. If an array is passed,
+     *      it's assumed that the token can be any of these.
+     * @param {variant} channel (Optional) The channel to read from. If not
+     *      provided, reads from the default (unnamed) channel.
+     * @return {Boolean} True if the token type matches, false if not.
+     * @method match
+     */
+    match: function(tokenTypes, channel) {
+
+        //always convert to an array, makes things easier
+        if (!(tokenTypes instanceof Array)) {
+            tokenTypes = [tokenTypes];
+        }
+
+        var tt  = this.get(channel),
+            i   = 0,
+            len = tokenTypes.length;
+
+        while (i < len) {
+            if (tt === tokenTypes[i++]) {
+                return true;
+            }
+        }
+
+        //no match found, put the token back
+        this.unget();
+        return false;
+    },
+
+    /**
+     * Determines if the next token matches the given token type.
+     * If so, that token is consumed; if not, an error is thrown.
+     * @param {int|int[]} tokenTypes Either a single token type or an array of
+     *      token types that the next token should be. If an array is passed,
+     *      it's assumed that the token must be one of these.
+     * @return {void}
+     * @method mustMatch
+     */
+    mustMatch: function(tokenTypes) {
+
+        var token;
+
+        //always convert to an array, makes things easier
+        if (!(tokenTypes instanceof Array)) {
+            tokenTypes = [tokenTypes];
+        }
+
+        if (!this.match.apply(this, arguments)) {
+            token = this.LT(1);
+            throw new SyntaxError("Expected " + this._tokenData[tokenTypes[0]].name +
+                " at line " + token.startLine + ", col " + token.startCol + ".", token.startLine, token.startCol);
+        }
+    },
+
+    //-------------------------------------------------------------------------
+    // Consuming methods
+    //-------------------------------------------------------------------------
+
+    /**
+     * Keeps reading from the token stream until either one of the specified
+     * token types is found or until the end of the input is reached.
+     * @param {int|int[]} tokenTypes Either a single token type or an array of
+     *      token types that the next token should be. If an array is passed,
+     *      it's assumed that the token must be one of these.
+     * @param {variant} channel (Optional) The channel to read from. If not
+     *      provided, reads from the default (unnamed) channel.
+     * @return {void}
+     * @method advance
+     */
+    advance: function(tokenTypes, channel) {
+
+        while (this.LA(0) !== 0 && !this.match(tokenTypes, channel)) {
+            this.get();
+        }
+
+        return this.LA(0);
+    },
+
+    /**
+     * Consumes the next token from the token stream.
+     * @return {int} The token type of the token that was just consumed.
+     * @method get
+     */
+    get: function(channel) {
+
+        var tokenInfo   = this._tokenData,
+            i           =0,
+            token,
+            info;
+
+        //check the lookahead buffer first
+        if (this._lt.length && this._ltIndex >= 0 && this._ltIndex < this._lt.length) {
+
+            i++;
+            this._token = this._lt[this._ltIndex++];
+            info = tokenInfo[this._token.type];
+
+            //obey channels logic
+            while ((info.channel !== undefined && channel !== info.channel) &&
+                    this._ltIndex < this._lt.length) {
+                this._token = this._lt[this._ltIndex++];
+                info = tokenInfo[this._token.type];
+                i++;
+            }
+
+            //here be dragons
+            if ((info.channel === undefined || channel === info.channel) &&
+                    this._ltIndex <= this._lt.length) {
+                this._ltIndexCache.push(i);
+                return this._token.type;
+            }
+        }
+
+        //call token retriever method
+        token = this._getToken();
+
+        //if it should be hidden, don't save a token
+        if (token.type > -1 && !tokenInfo[token.type].hide) {
+
+            //apply token channel
+            token.channel = tokenInfo[token.type].channel;
+
+            //save for later
+            this._token = token;
+            this._lt.push(token);
+
+            //save space that will be moved (must be done before array is truncated)
+            this._ltIndexCache.push(this._lt.length - this._ltIndex + i);
+
+            //keep the buffer under 5 items
+            if (this._lt.length > 5) {
+                this._lt.shift();
+            }
+
+            //also keep the shift buffer under 5 items
+            if (this._ltIndexCache.length > 5) {
+                this._ltIndexCache.shift();
+            }
+
+            //update lookahead index
+            this._ltIndex = this._lt.length;
+        }
+
+        /*
+         * Skip to the next token if:
+         * 1. The token type is marked as hidden.
+         * 2. The token type has a channel specified and it isn't the current channel.
+         */
+        info = tokenInfo[token.type];
+        if (info &&
+                (info.hide ||
+                (info.channel !== undefined && channel !== info.channel))) {
+            return this.get(channel);
+        } else {
+            //return just the type
+            return token.type;
+        }
+    },
+
+    /**
+     * Looks ahead a certain number of tokens and returns the token type at
+     * that position. This will throw an error if you lookahead past the
+     * end of input, past the size of the lookahead buffer, or back past
+     * the first token in the lookahead buffer.
+     * @param {int} The index of the token type to retrieve. 0 for the
+     *      current token, 1 for the next, -1 for the previous, etc.
+     * @return {int} The token type of the token in the given position.
+     * @method LA
+     */
+    LA: function(index) {
+        var total = index,
+            tt;
+        if (index > 0) {
+            //TODO: Store 5 somewhere
+            if (index > 5) {
+                throw new Error("Too much lookahead.");
+            }
+
+            //get all those tokens
+            while (total) {
+                tt = this.get();
+                total--;
+            }
+
+            //unget all those tokens
+            while (total < index) {
+                this.unget();
+                total++;
+            }
+        } else if (index < 0) {
+
+            if (this._lt[this._ltIndex+index]) {
+                tt = this._lt[this._ltIndex+index].type;
+            } else {
+                throw new Error("Too much lookbehind.");
+            }
+
+        } else {
+            tt = this._token.type;
+        }
+
+        return tt;
+
+    },
+
+    /**
+     * Looks ahead a certain number of tokens and returns the token at
+     * that position. This will throw an error if you lookahead past the
+     * end of input, past the size of the lookahead buffer, or back past
+     * the first token in the lookahead buffer.
+     * @param {int} The index of the token type to retrieve. 0 for the
+     *      current token, 1 for the next, -1 for the previous, etc.
+     * @return {Object} The token of the token in the given position.
+     * @method LA
+     */
+    LT: function(index) {
+
+        //lookahead first to prime the token buffer
+        this.LA(index);
+
+        //now find the token, subtract one because _ltIndex is already at the next index
+        return this._lt[this._ltIndex+index-1];
+    },
+
+    /**
+     * Returns the token type for the next token in the stream without
+     * consuming it.
+     * @return {int} The token type of the next token in the stream.
+     * @method peek
+     */
+    peek: function() {
+        return this.LA(1);
+    },
+
+    /**
+     * Returns the actual token object for the last consumed token.
+     * @return {Token} The token object for the last consumed token.
+     * @method token
+     */
+    token: function() {
+        return this._token;
+    },
+
+    /**
+     * Returns the name of the token for the given token type.
+     * @param {int} tokenType The type of token to get the name of.
+     * @return {String} The name of the token or "UNKNOWN_TOKEN" for any
+     *      invalid token type.
+     * @method tokenName
+     */
+    tokenName: function(tokenType) {
+        if (tokenType < 0 || tokenType > this._tokenData.length) {
+            return "UNKNOWN_TOKEN";
+        } else {
+            return this._tokenData[tokenType].name;
+        }
+    },
+
+    /**
+     * Returns the token type value for the given token name.
+     * @param {String} tokenName The name of the token whose value should be returned.
+     * @return {int} The token type value for the given token name or -1
+     *      for an unknown token.
+     * @method tokenName
+     */
+    tokenType: function(tokenName) {
+        return this._tokenData[tokenName] || -1;
+    },
+
+    /**
+     * Returns the last consumed token to the token stream.
+     * @method unget
+     */
+    unget: function() {
+        //if (this._ltIndex > -1) {
+        if (this._ltIndexCache.length) {
+            this._ltIndex -= this._ltIndexCache.pop();//--;
+            this._token = this._lt[this._ltIndex - 1];
+        } else {
+            throw new Error("Too much lookahead.");
+        }
+    }
+
+};
+
+
+},{"./StringReader":24,"./SyntaxError":25}],28:[function(require,module,exports){
+"use strict";
+
+module.exports = {
+    StringReader    : require("./StringReader"),
+    SyntaxError     : require("./SyntaxError"),
+    SyntaxUnit      : require("./SyntaxUnit"),
+    EventTarget     : require("./EventTarget"),
+    TokenStreamBase : require("./TokenStreamBase")
+};
+
+},{"./EventTarget":23,"./StringReader":24,"./SyntaxError":25,"./SyntaxUnit":26,"./TokenStreamBase":27}],"parserlib":[function(require,module,exports){
+"use strict";
+
+module.exports = {
+    css  : require("./css"),
+    util : require("./util")
+};
+
+},{"./css":22,"./util":28}]},{},[]);
+
+return require('parserlib');
 })();
-
-
 var clone = (function() {
 'use strict';
+
+var nativeMap;
+try {
+  nativeMap = Map;
+} catch(_) {
+  // maybe a reference error because no `Map`. Give it a dummy value that no
+  // value will ever be an instanceof.
+  nativeMap = function() {};
+}
+
+var nativeSet;
+try {
+  nativeSet = Set;
+} catch(_) {
+  nativeSet = function() {};
+}
+
+var nativePromise;
+try {
+  nativePromise = Promise;
+} catch(_) {
+  nativePromise = function() {};
+}
 
 /**
  * Clones (copies) an Object using deep copying.
@@ -6767,14 +7364,16 @@ var clone = (function() {
  *    a particular depth. (optional - defaults to Infinity)
  * @param `prototype` - sets the prototype to be used when cloning an object.
  *    (optional - defaults to parent prototype).
+ * @param `includeNonEnumerable` - set to true if the non-enumerable properties
+ *    should be cloned as well. Non-enumerable properties on the prototype
+ *    chain will be ignored. (optional - false by default)
 */
-function clone(parent, circular, depth, prototype) {
-  var filter;
+function clone(parent, circular, depth, prototype, includeNonEnumerable) {
   if (typeof circular === 'object') {
     depth = circular.depth;
     prototype = circular.prototype;
-    filter = circular.filter;
-    circular = circular.circular
+    includeNonEnumerable = circular.includeNonEnumerable;
+    circular = circular.circular;
   }
   // maintain two arrays for circular references, where corresponding parents
   // and children have the same index
@@ -6795,7 +7394,7 @@ function clone(parent, circular, depth, prototype) {
     if (parent === null)
       return null;
 
-    if (depth == 0)
+    if (depth === 0)
       return parent;
 
     var child;
@@ -6804,7 +7403,19 @@ function clone(parent, circular, depth, prototype) {
       return parent;
     }
 
-    if (clone.__isArray(parent)) {
+    if (parent instanceof nativeMap) {
+      child = new nativeMap();
+    } else if (parent instanceof nativeSet) {
+      child = new nativeSet();
+    } else if (parent instanceof nativePromise) {
+      child = new nativePromise(function (resolve, reject) {
+        parent.then(function(value) {
+          resolve(_clone(value, depth - 1));
+        }, function(err) {
+          reject(_clone(err, depth - 1));
+        });
+      });
+    } else if (clone.__isArray(parent)) {
       child = [];
     } else if (clone.__isRegExp(parent)) {
       child = new RegExp(parent.source, __getRegExpFlags(parent));
@@ -6815,6 +7426,8 @@ function clone(parent, circular, depth, prototype) {
       child = new Buffer(parent.length);
       parent.copy(child);
       return child;
+    } else if (parent instanceof Error) {
+      child = Object.create(parent);
     } else {
       if (typeof prototype == 'undefined') {
         proto = Object.getPrototypeOf(parent);
@@ -6836,6 +7449,30 @@ function clone(parent, circular, depth, prototype) {
       allChildren.push(child);
     }
 
+    if (parent instanceof nativeMap) {
+      var keyIterator = parent.keys();
+      while(true) {
+        var next = keyIterator.next();
+        if (next.done) {
+          break;
+        }
+        var keyChild = _clone(next.value, depth - 1);
+        var valueChild = _clone(parent.get(next.value), depth - 1);
+        child.set(keyChild, valueChild);
+      }
+    }
+    if (parent instanceof nativeSet) {
+      var iterator = parent.keys();
+      while(true) {
+        var next = iterator.next();
+        if (next.done) {
+          break;
+        }
+        var entryChild = _clone(next.value, depth - 1);
+        child.add(entryChild);
+      }
+    }
+
     for (var i in parent) {
       var attrs;
       if (proto) {
@@ -6846,6 +7483,40 @@ function clone(parent, circular, depth, prototype) {
         continue;
       }
       child[i] = _clone(parent[i], depth - 1);
+    }
+
+    if (Object.getOwnPropertySymbols) {
+      var symbols = Object.getOwnPropertySymbols(parent);
+      for (var i = 0; i < symbols.length; i++) {
+        // Don't need to worry about cloning a symbol because it is a primitive,
+        // like a number or string.
+        var symbol = symbols[i];
+        var descriptor = Object.getOwnPropertyDescriptor(parent, symbol);
+        if (descriptor && !descriptor.enumerable && !includeNonEnumerable) {
+          continue;
+        }
+        child[symbol] = _clone(parent[symbol], depth - 1);
+        if (!descriptor.enumerable) {
+          Object.defineProperty(child, symbol, {
+            enumerable: false
+          });
+        }
+      }
+    }
+
+    if (includeNonEnumerable) {
+      var allPropertyNames = Object.getOwnPropertyNames(parent);
+      for (var i = 0; i < allPropertyNames.length; i++) {
+        var propertyName = allPropertyNames[i];
+        var descriptor = Object.getOwnPropertyDescriptor(parent, propertyName);
+        if (descriptor && descriptor.enumerable) {
+          continue;
+        }
+        child[propertyName] = _clone(parent[propertyName], depth - 1);
+        Object.defineProperty(child, propertyName, {
+          enumerable: false
+        });
+      }
     }
 
     return child;
@@ -6874,22 +7545,22 @@ clone.clonePrototype = function clonePrototype(parent) {
 
 function __objToStr(o) {
   return Object.prototype.toString.call(o);
-};
+}
 clone.__objToStr = __objToStr;
 
 function __isDate(o) {
   return typeof o === 'object' && __objToStr(o) === '[object Date]';
-};
+}
 clone.__isDate = __isDate;
 
 function __isArray(o) {
   return typeof o === 'object' && __objToStr(o) === '[object Array]';
-};
+}
 clone.__isArray = __isArray;
 
 function __isRegExp(o) {
   return typeof o === 'object' && __objToStr(o) === '[object RegExp]';
-};
+}
 clone.__isRegExp = __isRegExp;
 
 function __getRegExpFlags(re) {
@@ -6898,7 +7569,7 @@ function __getRegExpFlags(re) {
   if (re.ignoreCase) flags += 'i';
   if (re.multiline) flags += 'm';
   return flags;
-};
+}
 clone.__getRegExpFlags = __getRegExpFlags;
 
 return clone;
@@ -6918,15 +7589,15 @@ if (typeof module === 'object' && module.exports) {
 /* global parserlib, clone, Reporter */
 /* exported CSSLint */
 
-var CSSLint = (function(){
+var CSSLint = (function() {
     "use strict";
 
     var rules           = [],
         formatters      = [],
-        embeddedRuleset = /\/\*csslint([^\*]*)\*\//,
+        embeddedRuleset = /\/\*\s*csslint([^\*]*)\*\//,
         api             = new parserlib.util.EventTarget();
 
-    api.version = "0.10.0";
+    api.version = "1.0.4";
 
     //-------------------------------------------------------------------------
     // Rule Management
@@ -6937,7 +7608,7 @@ var CSSLint = (function(){
      * @param {Object} rule The rule to add.
      * @method addRule
      */
-    api.addRule = function(rule){
+    api.addRule = function(rule) {
         rules.push(rule);
         rules[rule.id] = rule;
     };
@@ -6946,7 +7617,7 @@ var CSSLint = (function(){
      * Clears all rule from the engine.
      * @method clearRules
      */
-    api.clearRules = function(){
+    api.clearRules = function() {
         rules = [];
     };
 
@@ -6955,8 +7626,8 @@ var CSSLint = (function(){
      * @return An array of rule objects.
      * @method getRules
      */
-    api.getRules = function(){
-        return [].concat(rules).sort(function(a,b){
+    api.getRules = function() {
+        return [].concat(rules).sort(function(a, b) {
             return a.id > b.id ? 1 : 0;
         });
     };
@@ -6971,8 +7642,8 @@ var CSSLint = (function(){
             i = 0,
             len = rules.length;
 
-        while (i < len){
-            ruleset[rules[i++].id] = 1;    //by default, everything is a warning
+        while (i < len) {
+            ruleset[rules[i++].id] = 1;    // by default, everything is a warning
         }
 
         return ruleset;
@@ -6985,7 +7656,7 @@ var CSSLint = (function(){
      * @return {Object} A ruleset object.
      * @method getEmbeddedRuleset
      */
-    function applyEmbeddedRuleset(text, ruleset){
+    function applyEmbeddedRuleset(text, ruleset) {
         var valueMap,
             embedded = text && text.match(embeddedRuleset),
             rules = embedded && embedded[1];
@@ -7001,7 +7672,7 @@ var CSSLint = (function(){
                 "0": 0      // explicit ignore
             };
 
-            rules.toLowerCase().split(",").forEach(function(rule){
+            rules.toLowerCase().split(",").forEach(function(rule) {
                 var pair = rule.split(":"),
                     property = pair[0] || "",
                     value = pair[1] || "";
@@ -7033,7 +7704,7 @@ var CSSLint = (function(){
      * @return {Object} The formatter or undefined.
      * @method getFormatter
      */
-    api.getFormatter = function(formatId){
+    api.getFormatter = function(formatId) {
         return formatters[formatId];
     };
 
@@ -7050,7 +7721,7 @@ var CSSLint = (function(){
         var formatter = this.getFormatter(formatId),
             result = null;
 
-        if (formatter){
+        if (formatter) {
             result = formatter.startFormat();
             result += formatter.formatResults(results, filename, options || {});
             result += formatter.endFormat();
@@ -7065,7 +7736,7 @@ var CSSLint = (function(){
      * @return {Boolean} True if the format exists, false if not.
      * @method hasFormat
      */
-    api.hasFormat = function(formatId){
+    api.hasFormat = function(formatId) {
         return formatters.hasOwnProperty(formatId);
     };
 
@@ -7082,41 +7753,86 @@ var CSSLint = (function(){
      * @return {Object} Results of the verification.
      * @method verify
      */
-    api.verify = function(text, ruleset){
+    api.verify = function(text, ruleset) {
 
         var i = 0,
             reporter,
             lines,
+            allow = {},
+            ignore = [],
             report,
-            parser = new parserlib.css.Parser({ starHack: true, ieFilters: true,
-                                                underscoreHack: true, strict: false });
+            parser = new parserlib.css.Parser({
+                starHack: true,
+                ieFilters: true,
+                underscoreHack: true,
+                strict: false
+            });
 
         // normalize line endings
         lines = text.replace(/\n\r?/g, "$split$").split("$split$");
 
-        if (!ruleset){
+        // find 'allow' comments
+        CSSLint.Util.forEach(lines, function (line, lineno) {
+            var allowLine = line && line.match(/\/\*[ \t]*csslint[ \t]+allow:[ \t]*([^\*]*)\*\//i),
+                allowRules = allowLine && allowLine[1],
+                allowRuleset = {};
+
+            if (allowRules) {
+                allowRules.toLowerCase().split(",").forEach(function(allowRule) {
+                    allowRuleset[allowRule.trim()] = true;
+                });
+                if (Object.keys(allowRuleset).length > 0) {
+                    allow[lineno + 1] = allowRuleset;
+                }
+            }
+        });
+
+        var ignoreStart = null,
+            ignoreEnd = null;
+        CSSLint.Util.forEach(lines, function (line, lineno) {
+            // Keep oldest, "unclosest" ignore:start
+            if (ignoreStart === null && line.match(/\/\*[ \t]*csslint[ \t]+ignore:start[ \t]*\*\//i)) {
+                ignoreStart = lineno;
+            }
+
+            if (line.match(/\/\*[ \t]*csslint[ \t]+ignore:end[ \t]*\*\//i)) {
+                ignoreEnd = lineno;
+            }
+
+            if (ignoreStart !== null && ignoreEnd !== null) {
+                ignore.push([ignoreStart, ignoreEnd]);
+                ignoreStart = ignoreEnd = null;
+            }
+        });
+
+        // Close remaining ignore block, if any
+        if (ignoreStart !== null) {
+            ignore.push([ignoreStart, lines.length]);
+        }
+
+        if (!ruleset) {
             ruleset = this.getRuleset();
         }
 
-        if (embeddedRuleset.test(text)){
-            //defensively copy so that caller's version does not get modified
+        if (embeddedRuleset.test(text)) {
+            // defensively copy so that caller's version does not get modified
             ruleset = clone(ruleset);
             ruleset = applyEmbeddedRuleset(text, ruleset);
         }
 
-        reporter = new Reporter(lines, ruleset);
+        reporter = new Reporter(lines, ruleset, allow, ignore);
 
-        ruleset.errors = 2;       //always report parsing errors as errors
-        for (i in ruleset){
-            if(ruleset.hasOwnProperty(i) && ruleset[i]){
-                if (rules[i]){
+        ruleset.errors = 2;       // always report parsing errors as errors
+        for (i in ruleset) {
+            if (ruleset.hasOwnProperty(i) && ruleset[i]) {
+                if (rules[i]) {
                     rules[i].init(parser, reporter);
                 }
             }
         }
 
 
-        //capture most horrible error type
+        // capture most horrible error type
         try {
             parser.parse(text);
         } catch (ex) {
@@ -7126,14 +7842,16 @@ var CSSLint = (function(){
         report = {
             messages    : reporter.messages,
             stats       : reporter.stats,
-            ruleset     : reporter.ruleset
+            ruleset     : reporter.ruleset,
+            allow       : reporter.allow,
+            ignore      : reporter.ignore
         };
 
-        //sort by line numbers, rollups at the bottom
-        report.messages.sort(function (a, b){
-            if (a.rollup && !b.rollup){
+        // sort by line numbers, rollups at the bottom
+        report.messages.sort(function (a, b) {
+            if (a.rollup && !b.rollup) {
                 return 1;
-            } else if (!a.rollup && b.rollup){
+            } else if (!a.rollup && b.rollup) {
                 return -1;
             } else {
                 return a.line - b.line;
@@ -7159,8 +7877,10 @@ var CSSLint = (function(){
  * @param {String[]} lines The text lines of the source.
  * @param {Object} ruleset The set of rules to work with, including if
  *      they are errors or warnings.
+ * @param {Object} explicitly allowed lines
+ * @param {[][]} ingore list of line ranges to be ignored
  */
-function Reporter(lines, ruleset){
+function Reporter(lines, ruleset, allow, ignore) {
     "use strict";
 
     /**
@@ -7192,11 +7912,31 @@ function Reporter(lines, ruleset){
      * @type Object
      */
     this.ruleset = ruleset;
+
+    /**
+     * Lines with specific rule messages to leave out of the report.
+     * @property allow
+     * @type Object
+     */
+    this.allow = allow;
+    if (!this.allow) {
+        this.allow = {};
+    }
+
+    /**
+     * Linesets not to include in the report.
+     * @property ignore
+     * @type [][]
+     */
+    this.ignore = ignore;
+    if (!this.ignore) {
+        this.ignore = [];
+    }
 }
 
 Reporter.prototype = {
 
-    //restore constructor
+    // restore constructor
     constructor: Reporter,
 
     /**
@@ -7207,7 +7947,7 @@ Reporter.prototype = {
      * @param {Object} rule The rule this message relates to.
      * @method error
      */
-    error: function(message, line, col, rule){
+    error: function(message, line, col, rule) {
         "use strict";
         this.messages.push({
             type    : "error",
@@ -7228,7 +7968,7 @@ Reporter.prototype = {
      * @method warn
      * @deprecated Use report instead.
      */
-    warn: function(message, line, col, rule){
+    warn: function(message, line, col, rule) {
         "use strict";
         this.report(message, line, col, rule);
     },
@@ -7241,8 +7981,24 @@ Reporter.prototype = {
      * @param {Object} rule The rule this message relates to.
      * @method report
      */
-    report: function(message, line, col, rule){
+    report: function(message, line, col, rule) {
         "use strict";
+
+        // Check if rule violation should be allowed
+        if (this.allow.hasOwnProperty(line) && this.allow[line].hasOwnProperty(rule.id)) {
+            return;
+        }
+
+        var ignore = false;
+        CSSLint.Util.forEach(this.ignore, function (range) {
+            if (range[0] <= line && line <= range[1]) {
+                ignore = true;
+            }
+        });
+        if (ignore) {
+            return;
+        }
+
         this.messages.push({
             type    : this.ruleset[rule.id] === 2 ? "error" : "warning",
             line    : line,
@@ -7261,7 +8017,7 @@ Reporter.prototype = {
      * @param {Object} rule The rule this message relates to.
      * @method info
      */
-    info: function(message, line, col, rule){
+    info: function(message, line, col, rule) {
         "use strict";
         this.messages.push({
             type    : "info",
@@ -7279,7 +8035,7 @@ Reporter.prototype = {
      * @param {Object} rule The rule this message relates to.
      * @method rollupError
      */
-    rollupError: function(message, rule){
+    rollupError: function(message, rule) {
         "use strict";
         this.messages.push({
             type    : "error",
@@ -7295,7 +8051,7 @@ Reporter.prototype = {
      * @param {Object} rule The rule this message relates to.
      * @method rollupWarn
      */
-    rollupWarn: function(message, rule){
+    rollupWarn: function(message, rule) {
         "use strict";
         this.messages.push({
             type    : "warning",
@@ -7311,13 +8067,13 @@ Reporter.prototype = {
      * @param {Variant} value The value of the stat.
      * @method stat
      */
-    stat: function(name, value){
+    stat: function(name, value) {
         "use strict";
         this.stats[name] = value;
     }
 };
 
-//expose for testing purposes
+// expose for testing purposes
 CSSLint._Reporter = Reporter;
 
 /*
@@ -7327,17 +8083,17 @@ CSSLint.Util = {
     /*
      * Adds all properties from supplier onto receiver,
      * overwriting if the same name already exists on
-     * reciever.
+     * receiver.
      * @param {Object} The object to receive the properties.
      * @param {Object} The object to provide the properties.
      * @return {Object} The receiver
      */
-    mix: function(receiver, supplier){
+    mix: function(receiver, supplier) {
         "use strict";
         var prop;
 
-        for (prop in supplier){
-            if (supplier.hasOwnProperty(prop)){
+        for (prop in supplier) {
+            if (supplier.hasOwnProperty(prop)) {
                 receiver[prop] = supplier[prop];
             }
         }
@@ -7351,13 +8107,13 @@ CSSLint.Util = {
      * @param {Variant} value The value to search for.
      * @return {int} The index of the value if found, -1 if not.
      */
-    indexOf: function(values, value){
+    indexOf: function(values, value) {
         "use strict";
-        if (values.indexOf){
+        if (values.indexOf) {
             return values.indexOf(value);
         } else {
-            for (var i=0, len=values.length; i < len; i++){
-                if (values[i] === value){
+            for (var i=0, len=values.length; i < len; i++) {
+                if (values[i] === value) {
                     return i;
                 }
             }
@@ -7373,10 +8129,10 @@ CSSLint.Util = {
      */
     forEach: function(values, func) {
         "use strict";
-        if (values.forEach){
+        if (values.forEach) {
             return values.forEach(func);
         } else {
-            for (var i=0, len=values.length; i < len; i++){
+            for (var i=0, len=values.length; i < len; i++) {
                 func(values[i], i, values);
             }
         }
@@ -7389,17 +8145,18 @@ CSSLint.Util = {
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "adjoining-classes",
     name: "Disallow adjoining classes",
     desc: "Don't use adjoining classes.",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-adjoining-classes",
     browsers: "IE6",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this;
-        parser.addListener("startrule", function(event){
+        parser.addListener("startrule", function(event) {
             var selectors = event.selectors,
                 selector,
                 part,
@@ -7407,19 +8164,19 @@ CSSLint.addRule({
                 classCount,
                 i, j, k;
 
-            for (i=0; i < selectors.length; i++){
+            for (i=0; i < selectors.length; i++) {
                 selector = selectors[i];
-                for (j=0; j < selector.parts.length; j++){
+                for (j=0; j < selector.parts.length; j++) {
                     part = selector.parts[j];
-                    if (part.type === parser.SELECTOR_PART_TYPE){
+                    if (part.type === parser.SELECTOR_PART_TYPE) {
                         classCount = 0;
-                        for (k=0; k < part.modifiers.length; k++){
+                        for (k=0; k < part.modifiers.length; k++) {
                             modifier = part.modifiers[k];
-                            if (modifier.type === "class"){
+                            if (modifier.type === "class") {
                                 classCount++;
                             }
                             if (classCount > 1){
-                                reporter.report("Don't use adjoining classes.", part.line, part.col, rule);
+                                reporter.report("Adjoining classes: "+selectors[i].text, part.line, part.col, rule);
                             }
                         }
                     }
@@ -7435,14 +8192,15 @@ CSSLint.addRule({
  */
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "box-model",
     name: "Beware of broken box size",
     desc: "Don't use width or height when using padding or border.",
+    url: "https://github.com/CSSLint/csslint/wiki/Beware-of-box-model-size",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             widthProperties = {
@@ -7464,33 +8222,33 @@ CSSLint.addRule({
             properties,
             boxSizing = false;
 
-        function startRule(){
+        function startRule() {
             properties = {};
             boxSizing = false;
         }
 
-        function endRule(){
+        function endRule() {
             var prop, value;
 
             if (!boxSizing) {
-                if (properties.height){
-                    for (prop in heightProperties){
-                        if (heightProperties.hasOwnProperty(prop) && properties[prop]){
+                if (properties.height) {
+                    for (prop in heightProperties) {
+                        if (heightProperties.hasOwnProperty(prop) && properties[prop]) {
                             value = properties[prop].value;
-                            //special case for padding
-                            if (!(prop === "padding" && value.parts.length === 2 && value.parts[0].value === 0)){
+                            // special case for padding
+                            if (!(prop === "padding" && value.parts.length === 2 && value.parts[0].value === 0)) {
                                 reporter.report("Using height with " + prop + " can sometimes make elements larger than you expect.", properties[prop].line, properties[prop].col, rule);
                             }
                         }
                     }
                 }
 
-                if (properties.width){
-                    for (prop in widthProperties){
-                        if (widthProperties.hasOwnProperty(prop) && properties[prop]){
+                if (properties.width) {
+                    for (prop in widthProperties) {
+                        if (widthProperties.hasOwnProperty(prop) && properties[prop]) {
                             value = properties[prop].value;
 
-                            if (!(prop === "padding" && value.parts.length === 2 && value.parts[1].value === 0)){
+                            if (!(prop === "padding" && value.parts.length === 2 && value.parts[1].value === 0)) {
                                 reporter.report("Using width with " + prop + " can sometimes make elements larger than you expect.", properties[prop].line, properties[prop].col, rule);
                             }
                         }
@@ -7506,15 +8264,19 @@ CSSLint.addRule({
         parser.addListener("startkeyframerule", startRule);
         parser.addListener("startviewport", startRule);
 
-        parser.addListener("property", function(event){
+        parser.addListener("property", function(event) {
             var name = event.property.text.toLowerCase();
 
-            if (heightProperties[name] || widthProperties[name]){
-                if (!/^0\S*$/.test(event.value) && !(name === "border" && event.value.toString() === "none")){
-                    properties[name] = { line: event.property.line, col: event.property.col, value: event.value };
+            if (heightProperties[name] || widthProperties[name]) {
+                if (!/^0\S*$/.test(event.value) && !(name === "border" && event.value.toString() === "none")) {
+                    properties[name] = {
+                        line: event.property.line,
+                        col: event.property.col,
+                        value: event.value
+                    };
                 }
             } else {
-                if (/^(width|height)/i.test(name) && /^(length|percentage)/.test(event.value.parts[0].type)){
+                if (/^(width|height)/i.test(name) && /^(length|percentage)/.test(event.value.parts[0].type)) {
                     properties[name] = 1;
                 } else if (name === "box-sizing") {
                     boxSizing = true;
@@ -7539,22 +8301,23 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "box-sizing",
     name: "Disallow use of box-sizing",
     desc: "The box-sizing properties isn't supported in IE6 and IE7.",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-box-sizing",
     browsers: "IE6, IE7",
     tags: ["Compatibility"],
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this;
 
-        parser.addListener("property", function(event){
+        parser.addListener("property", function(event) {
             var name = event.property.text.toLowerCase();
 
-            if (name === "box-sizing"){
+            if (name === "box-sizing") {
                 reporter.report("The box-sizing property isn't supported in IE6 and IE7.", event.line, event.col, rule);
             }
         });
@@ -7569,38 +8332,39 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "bulletproof-font-face",
     name: "Use the bulletproof @font-face syntax",
     desc: "Use the bulletproof @font-face syntax to avoid 404's in old IE (http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax).",
+    url: "https://github.com/CSSLint/csslint/wiki/Bulletproof-font-face",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             fontFaceRule = false,
-            firstSrc     = true,
-            ruleFailed    = false,
+            firstSrc = true,
+            ruleFailed = false,
             line, col;
 
         // Mark the start of a @font-face declaration so we only test properties inside it
-        parser.addListener("startfontface", function(){
+        parser.addListener("startfontface", function() {
             fontFaceRule = true;
         });
 
-        parser.addListener("property", function(event){
+        parser.addListener("property", function(event) {
             // If we aren't inside an @font-face declaration then just return
             if (!fontFaceRule) {
                 return;
             }
 
             var propertyName = event.property.toString().toLowerCase(),
-                value        = event.value.toString();
+                value = event.value.toString();
 
             // Set the line and col numbers for use in the endfontface listener
             line = event.line;
-            col  = event.col;
+            col = event.col;
 
             // This is the property that we care about, we can ignore the rest
             if (propertyName === "src") {
@@ -7619,7 +8383,7 @@ CSSLint.addRule({
         });
 
         // Back to normal rules that we don't need to test
-        parser.addListener("endfontface", function(){
+        parser.addListener("endfontface", function() {
             fontFaceRule = false;
 
             if (ruleFailed) {
@@ -7636,13 +8400,14 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "compatible-vendor-prefixes",
     name: "Require compatible vendor prefixes",
     desc: "Include all compatible vendor prefixes to reach a wider range of users.",
+    url: "https://github.com/CSSLint/csslint/wiki/Require-compatible-vendor-prefixes",
     browsers: "All",
 
-    //initialization
+    // initialization
     init: function (parser, reporter) {
         "use strict";
         var rule = this,
@@ -7659,15 +8424,15 @@ CSSLint.addRule({
 
         // See http://peter.sh/experiments/vendor-prefixed-css-property-overview/ for details
         compatiblePrefixes = {
-            "animation"                  : "webkit moz",
-            "animation-delay"            : "webkit moz",
-            "animation-direction"        : "webkit moz",
-            "animation-duration"         : "webkit moz",
-            "animation-fill-mode"        : "webkit moz",
-            "animation-iteration-count"  : "webkit moz",
-            "animation-name"             : "webkit moz",
-            "animation-play-state"       : "webkit moz",
-            "animation-timing-function"  : "webkit moz",
+            "animation"                  : "webkit",
+            "animation-delay"            : "webkit",
+            "animation-direction"        : "webkit",
+            "animation-duration"         : "webkit",
+            "animation-fill-mode"        : "webkit",
+            "animation-iteration-count"  : "webkit",
+            "animation-name"             : "webkit",
+            "animation-play-state"       : "webkit",
+            "animation-timing-function"  : "webkit",
             "appearance"                 : "webkit moz",
             "border-end"                 : "webkit moz",
             "border-end-color"           : "webkit moz",
@@ -7686,8 +8451,8 @@ CSSLint.addRule({
             "box-ordinal-group"          : "webkit moz ms",
             "box-orient"                 : "webkit moz ms",
             "box-pack"                   : "webkit moz ms",
-            "box-sizing"                 : "webkit moz",
-            "box-shadow"                 : "webkit moz",
+            "box-sizing"                 : "",
+            "box-shadow"                 : "",
             "column-count"               : "webkit moz ms",
             "column-gap"                 : "webkit moz ms",
             "column-rule"                : "webkit moz ms",
@@ -7705,13 +8470,13 @@ CSSLint.addRule({
             "padding-start"              : "webkit moz",
             "tab-size"                   : "moz o",
             "text-size-adjust"           : "webkit ms",
-            "transform"                  : "webkit moz ms o",
-            "transform-origin"           : "webkit moz ms o",
-            "transition"                 : "webkit moz o",
-            "transition-delay"           : "webkit moz o",
-            "transition-duration"        : "webkit moz o",
-            "transition-property"        : "webkit moz o",
-            "transition-timing-function" : "webkit moz o",
+            "transform"                  : "webkit ms",
+            "transform-origin"           : "webkit ms",
+            "transition"                 : "",
+            "transition-delay"           : "",
+            "transition-duration"        : "",
+            "transition-property"        : "",
+            "transition-timing-function" : "",
             "user-modify"                : "webkit moz",
             "user-select"                : "webkit moz ms",
             "word-break"                 : "epub ms",
@@ -7781,8 +8546,8 @@ CSSLint.addRule({
                         if (CSSLint.Util.indexOf(variations, name.text) > -1) {
                             if (!propertyGroups[prop]) {
                                 propertyGroups[prop] = {
-                                    full : variations.slice(0),
-                                    actual : [],
+                                    full: variations.slice(0),
+                                    actual: [],
                                     actualNodes: []
                                 };
                             }
@@ -7827,14 +8592,15 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "display-property-grouping",
     name: "Require properties appropriate for display",
     desc: "Certain properties shouldn't be used with certain display property values.",
+    url: "https://github.com/CSSLint/csslint/wiki/Require-properties-appropriate-for-display",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this;
 
@@ -7857,26 +8623,26 @@ CSSLint.addRule({
             },
             properties;
 
-        function reportProperty(name, display, msg){
-            if (properties[name]){
-                if (typeof propertiesToCheck[name] !== "string" || properties[name].value.toLowerCase() !== propertiesToCheck[name]){
+        function reportProperty(name, display, msg) {
+            if (properties[name]) {
+                if (typeof propertiesToCheck[name] !== "string" || properties[name].value.toLowerCase() !== propertiesToCheck[name]) {
                     reporter.report(msg || name + " can't be used with display: " + display + ".", properties[name].line, properties[name].col, rule);
                 }
             }
         }
 
-        function startRule(){
+        function startRule() {
             properties = {};
         }
 
-        function endRule(){
+        function endRule() {
 
             var display = properties.display ? properties.display.value : null;
-            if (display){
-                switch(display){
+            if (display) {
+                switch (display) {
 
                     case "inline":
-                        //height, width, margin-top, margin-bottom, float should not be used with inline
+                        // height, width, margin-top, margin-bottom, float should not be used with inline
                         reportProperty("height", display);
                         reportProperty("width", display);
                         reportProperty("margin", display);
@@ -7886,18 +8652,18 @@ CSSLint.addRule({
                         break;
 
                     case "block":
-                        //vertical-align should not be used with block
+                        // vertical-align should not be used with block
                         reportProperty("vertical-align", display);
                         break;
 
                     case "inline-block":
-                        //float should not be used with inline-block
+                        // float should not be used with inline-block
                         reportProperty("float", display);
                         break;
 
                     default:
-                        //margin, float should not be used with table
-                        if (display.indexOf("table-") === 0){
+                        // margin, float should not be used with table
+                        if (display.indexOf("table-") === 0) {
                             reportProperty("margin", display);
                             reportProperty("margin-left", display);
                             reportProperty("margin-right", display);
@@ -7906,7 +8672,7 @@ CSSLint.addRule({
                             reportProperty("float", display);
                         }
 
-                        //otherwise do nothing
+                        // otherwise do nothing
                 }
             }
 
@@ -7919,11 +8685,15 @@ CSSLint.addRule({
         parser.addListener("startpage", startRule);
         parser.addListener("startviewport", startRule);
 
-        parser.addListener("property", function(event){
+        parser.addListener("property", function(event) {
             var name = event.property.text.toLowerCase();
 
-            if (propertiesToCheck[name]){
-                properties[name] = { value: event.value.text, line: event.property.line, col: event.property.col };
+            if (propertiesToCheck[name]) {
+                properties[name] = {
+                    value: event.value.text,
+                    line: event.property.line,
+                    col: event.property.col
+                };
             }
         });
 
@@ -7944,19 +8714,20 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "duplicate-background-images",
     name: "Disallow duplicate background images",
     desc: "Every background-image should be unique. Use a common class for e.g. sprites.",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-duplicate-background-images",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             stack = {};
 
-        parser.addListener("property", function(event){
+        parser.addListener("property", function(event) {
             var name = event.property.text,
                 value = event.value,
                 i, len;
@@ -7966,8 +8737,7 @@ CSSLint.addRule({
                     if (value.parts[i].type === "uri") {
                         if (typeof stack[value.parts[i].uri] === "undefined") {
                             stack[value.parts[i].uri] = event;
-                        }
-                        else {
+                        } else {
                             reporter.report("Background image '" + value.parts[i].uri + "' was used multiple times, first declared at line " + stack[value.parts[i].uri].line + ", col " + stack[value.parts[i].uri].col + ".", event.line, event.col, rule);
                         }
                     }
@@ -7984,20 +8754,21 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "duplicate-properties",
     name: "Disallow duplicate properties",
     desc: "Duplicate properties must appear one after the other.",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-duplicate-properties",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             properties,
             lastProperty;
 
-        function startRule(){
+        function startRule() {
             properties = {};
         }
 
@@ -8008,11 +8779,11 @@ CSSLint.addRule({
         parser.addListener("startkeyframerule", startRule);
         parser.addListener("startviewport", startRule);
 
-        parser.addListener("property", function(event){
+        parser.addListener("property", function(event) {
             var property = event.property,
                 name = property.text.toLowerCase();
 
-            if (properties[name] && (lastProperty !== name || properties[name] === event.value.text)){
+            if (properties[name] && (lastProperty !== name || properties[name] === event.value.text)) {
                 reporter.report("Duplicate property '" + event.property + "' found.", event.line, event.col, rule);
             }
 
@@ -8032,29 +8803,30 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "empty-rules",
     name: "Disallow empty rules",
     desc: "Rules without any properties specified should be removed.",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-empty-rules",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             count = 0;
 
-        parser.addListener("startrule", function(){
+        parser.addListener("startrule", function() {
             count=0;
         });
 
-        parser.addListener("property", function(){
+        parser.addListener("property", function() {
             count++;
         });
 
-        parser.addListener("endrule", function(event){
+        parser.addListener("endrule", function(event) {
             var selectors = event.selectors;
-            if (count === 0){
+            if (count === 0) {
                 reporter.report("Rule is empty.", selectors[0].line, selectors[0].col, rule);
             }
         });
@@ -8068,18 +8840,18 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "errors",
     name: "Parsing Errors",
     desc: "This rule looks for recoverable syntax errors.",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this;
 
-        parser.addListener("error", function(event){
+        parser.addListener("error", function(event) {
             reporter.error(event.message, event.line, event.col, rule);
         });
 
@@ -8089,14 +8861,15 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "fallback-colors",
     name: "Require fallback colors",
     desc: "For older browsers that don't support RGBA, HSL, or HSLA, provide a fallback color.",
+    url: "https://github.com/CSSLint/csslint/wiki/Require-fallback-colors",
     browsers: "IE6,IE7,IE8",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             lastProperty,
@@ -8114,11 +8887,9 @@ CSSLint.addRule({
                 "border-bottom": 1,
                 "border-left": 1,
                 "background-color": 1
-            },
-            properties;
+            };
 
-        function startRule(){
-            properties = {};
+        function startRule() {
             lastProperty = null;
         }
 
@@ -8129,7 +8900,7 @@ CSSLint.addRule({
         parser.addListener("startkeyframerule", startRule);
         parser.addListener("startviewport", startRule);
 
-        parser.addListener("property", function(event){
+        parser.addListener("property", function(event) {
             var property = event.property,
                 name = property.text.toLowerCase(),
                 parts = event.value.parts,
@@ -8137,16 +8908,16 @@ CSSLint.addRule({
                 colorType = "",
                 len = parts.length;
 
-            if(propertiesToCheck[name]){
-                while(i < len){
-                    if (parts[i].type === "color"){
-                        if ("alpha" in parts[i] || "hue" in parts[i]){
+            if (propertiesToCheck[name]) {
+                while (i < len) {
+                    if (parts[i].type === "color") {
+                        if ("alpha" in parts[i] || "hue" in parts[i]) {
 
-                            if (/([^\)]+)\(/.test(parts[i])){
+                            if (/([^\)]+)\(/.test(parts[i])) {
                                 colorType = RegExp.$1.toUpperCase();
                             }
 
-                            if (!lastProperty || (lastProperty.property.text.toLowerCase() !== name || lastProperty.colorType !== "compat")){
+                            if (!lastProperty || (lastProperty.property.text.toLowerCase() !== name || lastProperty.colorType !== "compat")) {
                                 reporter.report("Fallback " + name + " (hex or RGB) should precede " + colorType + " " + name + ".", event.line, event.col, rule);
                             }
                         } else {
@@ -8172,30 +8943,31 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "floats",
     name: "Disallow too many floats",
     desc: "This rule tests if the float property is used too many times",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-too-many-floats",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this;
         var count = 0;
 
-        //count how many times "float" is used
-        parser.addListener("property", function(event){
+        // count how many times "float" is used
+        parser.addListener("property", function(event) {
             if (event.property.text.toLowerCase() === "float" &&
-                    event.value.text.toLowerCase() !== "none"){
+                    event.value.text.toLowerCase() !== "none") {
                 count++;
             }
         });
 
-        //report the results
-        parser.addListener("endstylesheet", function(){
+        // report the results
+        parser.addListener("endstylesheet", function() {
             reporter.stat("floats", count);
-            if (count >= 10){
+            if (count >= 10) {
                 reporter.rollupWarn("Too many floats (" + count + "), you're probably using them for layout. Consider using a grid system instead.", rule);
             }
         });
@@ -8209,25 +8981,26 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "font-faces",
     name: "Don't use too many web fonts",
     desc: "Too many different web fonts in the same stylesheet.",
+    url: "https://github.com/CSSLint/csslint/wiki/Don%27t-use-too-many-web-fonts",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             count = 0;
 
 
-        parser.addListener("startfontface", function(){
+        parser.addListener("startfontface", function() {
             count++;
         });
 
-        parser.addListener("endstylesheet", function(){
-            if (count > 5){
+        parser.addListener("endstylesheet", function() {
+            if (count > 5) {
                 reporter.rollupWarn("Too many @font-face declarations (" + count + ").", rule);
             }
         });
@@ -8241,29 +9014,30 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "font-sizes",
     name: "Disallow too many font sizes",
     desc: "Checks the number of font-size declarations.",
+    url: "https://github.com/CSSLint/csslint/wiki/Don%27t-use-too-many-font-size-declarations",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             count = 0;
 
-        //check for use of "font-size"
-        parser.addListener("property", function(event){
-            if (event.property.toString() === "font-size"){
+        // check for use of "font-size"
+        parser.addListener("property", function(event) {
+            if (event.property.toString() === "font-size") {
                 count++;
             }
         });
 
-        //report the results
-        parser.addListener("endstylesheet", function(){
+        // report the results
+        parser.addListener("endstylesheet", function() {
             reporter.stat("font-sizes", count);
-            if (count >= 10){
+            if (count >= 10) {
                 reporter.rollupWarn("Too many font-size declarations (" + count + "), abstraction needed.", rule);
             }
         });
@@ -8277,19 +9051,20 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "gradients",
     name: "Require all gradient definitions",
     desc: "When using a vendor-prefixed gradient, make sure to use them all.",
+    url: "https://github.com/CSSLint/csslint/wiki/Require-all-gradient-definitions",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             gradients;
 
-        parser.addListener("startrule", function(){
+        parser.addListener("startrule", function() {
             gradients = {
                 moz: 0,
                 webkit: 0,
@@ -8298,36 +9073,36 @@ CSSLint.addRule({
             };
         });
 
-        parser.addListener("property", function(event){
+        parser.addListener("property", function(event) {
 
-            if (/\-(moz|o|webkit)(?:\-(?:linear|radial))\-gradient/i.test(event.value)){
+            if (/\-(moz|o|webkit)(?:\-(?:linear|radial))\-gradient/i.test(event.value)) {
                 gradients[RegExp.$1] = 1;
-            } else if (/\-webkit\-gradient/i.test(event.value)){
+            } else if (/\-webkit\-gradient/i.test(event.value)) {
                 gradients.oldWebkit = 1;
             }
 
         });
 
-        parser.addListener("endrule", function(event){
+        parser.addListener("endrule", function(event) {
             var missing = [];
 
-            if (!gradients.moz){
+            if (!gradients.moz) {
                 missing.push("Firefox 3.6+");
             }
 
-            if (!gradients.webkit){
+            if (!gradients.webkit) {
                 missing.push("Webkit (Safari 5+, Chrome)");
             }
 
-            if (!gradients.oldWebkit){
+            if (!gradients.oldWebkit) {
                 missing.push("Old Webkit (Safari 4+, Chrome)");
             }
 
-            if (!gradients.o){
+            if (!gradients.o) {
                 missing.push("Opera 11.1+");
             }
 
-            if (missing.length && missing.length < 4){
+            if (missing.length && missing.length < 4) {
                 reporter.report("Missing vendor-prefixed CSS gradients for " + missing.join(", ") + ".", event.selectors[0].line, event.selectors[0].col, rule);
             }
 
@@ -8343,17 +9118,18 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "ids",
     name: "Disallow IDs in selectors",
     desc: "Selectors should not contain IDs.",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-IDs-in-selectors",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this;
-        parser.addListener("startrule", function(event){
+        parser.addListener("startrule", function(event) {
             var selectors = event.selectors,
                 selector,
                 part,
@@ -8361,29 +9137,72 @@ CSSLint.addRule({
                 idCount,
                 i, j, k;
 
-            for (i=0; i < selectors.length; i++){
+            for (i=0; i < selectors.length; i++) {
                 selector = selectors[i];
                 idCount = 0;
 
-                for (j=0; j < selector.parts.length; j++){
+                for (j=0; j < selector.parts.length; j++) {
                     part = selector.parts[j];
-                    if (part.type === parser.SELECTOR_PART_TYPE){
-                        for (k=0; k < part.modifiers.length; k++){
+                    if (part.type === parser.SELECTOR_PART_TYPE) {
+                        for (k=0; k < part.modifiers.length; k++) {
                             modifier = part.modifiers[k];
-                            if (modifier.type === "id"){
+                            if (modifier.type === "id") {
                                 idCount++;
                             }
                         }
                     }
                 }
 
-                if (idCount === 1){
+                if (idCount === 1) {
                     reporter.report("Don't use IDs in selectors.", selector.line, selector.col, rule);
-                } else if (idCount > 1){
+                } else if (idCount > 1) {
                     reporter.report(idCount + " IDs in the selector, really?", selector.line, selector.col, rule);
                 }
             }
 
+        });
+    }
+
+});
+
+/*
+ * Rule: IE6-9 supports up to 31 stylesheet import.
+ * Reference:
+ * http://blogs.msdn.com/b/ieinternals/archive/2011/05/14/internet-explorer-stylesheet-rule-selector-import-sheet-limit-maximum.aspx
+ */
+
+CSSLint.addRule({
+
+    // rule information
+    id: "import-ie-limit",
+    name: "@import limit on IE6-IE9",
+    desc: "IE6-9 supports up to 31 @import per stylesheet",
+    browsers: "IE6, IE7, IE8, IE9",
+
+    // initialization
+    init: function(parser, reporter) {
+        "use strict";
+        var rule = this,
+            MAX_IMPORT_COUNT = 31,
+            count = 0;
+
+        function startPage() {
+            count = 0;
+        }
+
+        parser.addListener("startpage", startPage);
+
+        parser.addListener("import", function() {
+            count++;
+        });
+
+        parser.addListener("endstylesheet", function() {
+            if (count > MAX_IMPORT_COUNT) {
+                reporter.rollupError(
+                    "Too many @import rules (" + count + "). IE6-9 supports up to 31 import per stylesheet.",
+                    rule
+                );
+            }
         });
     }
 
@@ -8395,18 +9214,19 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "import",
     name: "Disallow @import",
     desc: "Don't use @import, use <link> instead.",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-%40import",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this;
 
-        parser.addListener("import", function(event){
+        parser.addListener("import", function(event) {
             reporter.report("@import prevents parallel downloads, use <link> instead.", event.line, event.col, rule);
         });
 
@@ -8422,30 +9242,31 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "important",
     name: "Disallow !important",
     desc: "Be careful when using !important declaration",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-%21important",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             count = 0;
 
-        //warn that important is used and increment the declaration counter
-        parser.addListener("property", function(event){
-            if (event.important === true){
+        // warn that important is used and increment the declaration counter
+        parser.addListener("property", function(event) {
+            if (event.important === true) {
                 count++;
                 reporter.report("Use of !important", event.line, event.col, rule);
             }
         });
 
-        //if there are more than 10, show an error
-        parser.addListener("endstylesheet", function(){
+        // if there are more than 10, show an error
+        parser.addListener("endstylesheet", function() {
             reporter.stat("important", count);
-            if (count >= 10){
+            if (count >= 10) {
                 reporter.rollupWarn("Too many !important declarations (" + count + "), try to use less than 10 to avoid specificity issues.", rule);
             }
         });
@@ -8460,18 +9281,19 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "known-properties",
     name: "Require use of known properties",
     desc: "Properties should be known (listed in CSS3 specification) or be a vendor-prefixed property.",
+    url: "https://github.com/CSSLint/csslint/wiki/Require-use-of-known-properties",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this;
 
-        parser.addListener("property", function(event){
+        parser.addListener("property", function(event) {
 
             // the check is handled entirely by the parser-lib (https://github.com/nzakas/parser-lib)
             if (event.invalid) {
@@ -8484,19 +9306,19 @@ CSSLint.addRule({
 });
 
 /*
- * Rule: All properties should be in alphabetical order..
+ * Rule: All properties should be in alphabetical order.
  */
-/*global CSSLint*/
+
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "order-alphabetical",
     name: "Alphabetical order",
     desc: "Assure properties are in alphabetical order",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             properties;
@@ -8505,14 +9327,14 @@ CSSLint.addRule({
             properties = [];
         };
 
-        var endRule = function(event){
+        var endRule = function(event) {
             var currentProperties = properties.join(","),
                 expectedProperties = properties.sort().join(",");
 
-            if (currentProperties !== expectedProperties){
-                reporter.report("Rule doesn't have all its properties in alphabetical ordered.", event.line, event.col, rule);
+            if (currentProperties !== expectedProperties) {
+                reporter.report("Rule doesn't have all its properties in alphabetical order.", event.line, event.col, rule);
             }
-          };
+        };
 
         parser.addListener("startrule", startRule);
         parser.addListener("startfontface", startRule);
@@ -8521,7 +9343,7 @@ CSSLint.addRule({
         parser.addListener("startkeyframerule", startRule);
         parser.addListener("startviewport", startRule);
 
-        parser.addListener("property", function(event){
+        parser.addListener("property", function(event) {
             var name = event.property.text,
                 lowerCasePrefixLessName = name.toLowerCase().replace(/^-.*?-/, "");
 
@@ -8545,21 +9367,22 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "outline-none",
     name: "Disallow outline: none",
     desc: "Use of outline: none or outline: 0 should be limited to :focus rules.",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-outline%3Anone",
     browsers: "All",
     tags: ["Accessibility"],
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             lastRule;
 
-        function startRule(event){
-            if (event.selectors){
+        function startRule(event) {
+            if (event.selectors) {
                 lastRule = {
                     line: event.line,
                     col: event.col,
@@ -8572,10 +9395,10 @@ CSSLint.addRule({
             }
         }
 
-        function endRule(){
-            if (lastRule){
-                if (lastRule.outline){
-                    if (lastRule.selectors.toString().toLowerCase().indexOf(":focus") === -1){
+        function endRule() {
+            if (lastRule) {
+                if (lastRule.outline) {
+                    if (lastRule.selectors.toString().toLowerCase().indexOf(":focus") === -1) {
                         reporter.report("Outlines should only be modified using :focus.", lastRule.line, lastRule.col, rule);
                     } else if (lastRule.propCount === 1) {
                         reporter.report("Outlines shouldn't be hidden unless other visual changes are made.", lastRule.line, lastRule.col, rule);
@@ -8591,13 +9414,13 @@ CSSLint.addRule({
         parser.addListener("startkeyframerule", startRule);
         parser.addListener("startviewport", startRule);
 
-        parser.addListener("property", function(event){
+        parser.addListener("property", function(event) {
             var name = event.property.text.toLowerCase(),
                 value = event.value;
 
-            if (lastRule){
+            if (lastRule) {
                 lastRule.propCount++;
-                if (name === "outline" && (value.toString() === "none" || value.toString() === "0")){
+                if (name === "outline" && (value.toString() === "none" || value.toString() === "0")) {
                     lastRule.outline = true;
                 }
             }
@@ -8621,41 +9444,45 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "overqualified-elements",
     name: "Disallow overqualified elements",
     desc: "Don't use classes or IDs with elements (a.foo or a#foo).",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-overqualified-elements",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             classes = {};
 
-        parser.addListener("startrule", function(event){
+        parser.addListener("startrule", function(event) {
             var selectors = event.selectors,
                 selector,
                 part,
                 modifier,
                 i, j, k;
 
-            for (i=0; i < selectors.length; i++){
+            for (i=0; i < selectors.length; i++) {
                 selector = selectors[i];
 
-                for (j=0; j < selector.parts.length; j++){
+                for (j=0; j < selector.parts.length; j++) {
                     part = selector.parts[j];
-                    if (part.type === parser.SELECTOR_PART_TYPE){
-                        for (k=0; k < part.modifiers.length; k++){
+                    if (part.type === parser.SELECTOR_PART_TYPE) {
+                        for (k=0; k < part.modifiers.length; k++) {
                             modifier = part.modifiers[k];
-                            if (part.elementName && modifier.type === "id"){
+                            if (part.elementName && modifier.type === "id") {
                                 reporter.report("Element (" + part + ") is overqualified, just use " + modifier + " without element name.", part.line, part.col, rule);
-                            } else if (modifier.type === "class"){
+                            } else if (modifier.type === "class") {
 
-                                if (!classes[modifier]){
+                                if (!classes[modifier]) {
                                     classes[modifier] = [];
                                 }
-                                classes[modifier].push({ modifier: modifier, part: part });
+                                classes[modifier].push({
+                                    modifier: modifier,
+                                    part: part
+                                });
                             }
                         }
                     }
@@ -8663,14 +9490,14 @@ CSSLint.addRule({
             }
         });
 
-        parser.addListener("endstylesheet", function(){
+        parser.addListener("endstylesheet", function() {
 
             var prop;
-            for (prop in classes){
-                if (classes.hasOwnProperty(prop)){
+            for (prop in classes) {
+                if (classes.hasOwnProperty(prop)) {
 
-                    //one use means that this is overqualified
-                    if (classes[prop].length === 1 && classes[prop][0].part.elementName){
+                    // one use means that this is overqualified
+                    if (classes[prop].length === 1 && classes[prop][0].part.elementName) {
                         reporter.report("Element (" + classes[prop][0].part + ") is overqualified, just use " + classes[prop][0].modifier + " without element name.", classes[prop][0].part.line, classes[prop][0].part.col, rule);
                     }
                 }
@@ -8686,30 +9513,31 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "qualified-headings",
     name: "Disallow qualified headings",
     desc: "Headings should not be qualified (namespaced).",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-qualified-headings",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this;
 
-        parser.addListener("startrule", function(event){
+        parser.addListener("startrule", function(event) {
             var selectors = event.selectors,
                 selector,
                 part,
                 i, j;
 
-            for (i=0; i < selectors.length; i++){
+            for (i=0; i < selectors.length; i++) {
                 selector = selectors[i];
 
-                for (j=0; j < selector.parts.length; j++){
+                for (j=0; j < selector.parts.length; j++) {
                     part = selector.parts[j];
-                    if (part.type === parser.SELECTOR_PART_TYPE){
-                        if (part.elementName && /h[1-6]/.test(part.elementName.toString()) && j > 0){
+                    if (part.type === parser.SELECTOR_PART_TYPE) {
+                        if (part.elementName && /h[1-6]/.test(part.elementName.toString()) && j > 0) {
                             reporter.report("Heading (" + part.elementName + ") should not be qualified.", part.line, part.col, rule);
                         }
                     }
@@ -8726,33 +9554,34 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "regex-selectors",
     name: "Disallow selectors that look like regexs",
     desc: "Selectors that look like regular expressions are slow and should be avoided.",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-selectors-that-look-like-regular-expressions",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this;
 
-        parser.addListener("startrule", function(event){
+        parser.addListener("startrule", function(event) {
             var selectors = event.selectors,
                 selector,
                 part,
                 modifier,
                 i, j, k;
 
-            for (i=0; i < selectors.length; i++){
+            for (i=0; i < selectors.length; i++) {
                 selector = selectors[i];
-                for (j=0; j < selector.parts.length; j++){
+                for (j=0; j < selector.parts.length; j++) {
                     part = selector.parts[j];
-                    if (part.type === parser.SELECTOR_PART_TYPE){
-                        for (k=0; k < part.modifiers.length; k++){
+                    if (part.type === parser.SELECTOR_PART_TYPE) {
+                        for (k=0; k < part.modifiers.length; k++) {
                             modifier = part.modifiers[k];
-                            if (modifier.type === "attribute"){
-                                if (/([\~\|\^\$\*]=)/.test(modifier)){
+                            if (modifier.type === "attribute") {
+                                if (/([~\|\^\$\*]=)/.test(modifier)) {
                                     reporter.report("Attribute selectors with " + RegExp.$1 + " are slow!", modifier.line, modifier.col, rule);
                                 }
                             }
@@ -8772,23 +9601,23 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "rules-count",
     name: "Rules Count",
     desc: "Track how many rules there are.",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var count = 0;
 
-        //count each rule
-        parser.addListener("startrule", function(){
+        // count each rule
+        parser.addListener("startrule", function() {
             count++;
         });
 
-        parser.addListener("endstylesheet", function(){
+        parser.addListener("endstylesheet", function() {
             reporter.stat("rule-count", count);
         });
     }
@@ -8801,13 +9630,13 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "selector-max-approaching",
     name: "Warn when approaching the 4095 selector limit for IE",
     desc: "Will warn when selector count is >= 3800 selectors.",
     browsers: "IE",
 
-    //initialization
+    // initialization
     init: function(parser, reporter) {
         "use strict";
         var rule = this, count = 0;
@@ -8818,7 +9647,7 @@ CSSLint.addRule({
 
         parser.addListener("endstylesheet", function() {
             if (count >= 3800) {
-                reporter.report("You have " + count + " selectors. Internet Explorer supports a maximum of 4095 selectors per stylesheet. Consider refactoring.",0,0,rule);
+                reporter.report("You have " + count + " selectors. Internet Explorer supports a maximum of 4095 selectors per stylesheet. Consider refactoring.", 0, 0, rule);
             }
         });
     }
@@ -8831,14 +9660,14 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "selector-max",
     name: "Error when past the 4095 selector limit for IE",
     desc: "Will error when selector count is > 4095.",
     browsers: "IE",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this, count = 0;
 
@@ -8848,7 +9677,7 @@ CSSLint.addRule({
 
         parser.addListener("endstylesheet", function() {
             if (count > 4095) {
-                reporter.report("You have " + count + " selectors. Internet Explorer supports a maximum of 4095 selectors per stylesheet. Consider refactoring.",0,0,rule);
+                reporter.report("You have " + count + " selectors. Internet Explorer supports a maximum of 4095 selectors per stylesheet. Consider refactoring.", 0, 0, rule);
             }
         });
     }
@@ -8861,13 +9690,13 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "selector-newline",
     name: "Disallow new-line characters in selectors",
     desc: "New-line characters in selectors are usually a forgotten comma and not a descendant combinator.",
     browsers: "All",
 
-    //initialization
+    // initialization
     init: function(parser, reporter) {
         "use strict";
         var rule = this;
@@ -8907,14 +9736,15 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "shorthand",
     name: "Require shorthand properties",
     desc: "Use shorthand properties where possible.",
+    url: "https://github.com/CSSLint/csslint/wiki/Require-shorthand-properties",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             prop, i, len,
@@ -8935,34 +9765,34 @@ CSSLint.addRule({
                 ]
             };
 
-        //initialize propertiesToCheck
-        for (prop in mapping){
-            if (mapping.hasOwnProperty(prop)){
-                for (i=0, len=mapping[prop].length; i < len; i++){
+        // initialize propertiesToCheck
+        for (prop in mapping) {
+            if (mapping.hasOwnProperty(prop)) {
+                for (i=0, len=mapping[prop].length; i < len; i++) {
                     propertiesToCheck[mapping[prop][i]] = prop;
                 }
             }
         }
 
-        function startRule(){
+        function startRule() {
             properties = {};
         }
 
-        //event handler for end of rules
-        function endRule(event){
+        // event handler for end of rules
+        function endRule(event) {
 
             var prop, i, len, total;
 
-            //check which properties this rule has
-            for (prop in mapping){
-                if (mapping.hasOwnProperty(prop)){
+            // check which properties this rule has
+            for (prop in mapping) {
+                if (mapping.hasOwnProperty(prop)) {
                     total=0;
 
-                    for (i=0, len=mapping[prop].length; i < len; i++){
+                    for (i=0, len=mapping[prop].length; i < len; i++) {
                         total += properties[mapping[prop][i]] ? 1 : 0;
                     }
 
-                    if (total === mapping[prop].length){
+                    if (total === mapping[prop].length) {
                         reporter.report("The properties " + mapping[prop].join(", ") + " can be replaced by " + prop + ".", event.line, event.col, rule);
                     }
                 }
@@ -8972,11 +9802,11 @@ CSSLint.addRule({
         parser.addListener("startrule", startRule);
         parser.addListener("startfontface", startRule);
 
-        //check for use of "font-size"
-        parser.addListener("property", function(event){
+        // check for use of "font-size"
+        parser.addListener("property", function(event) {
             var name = event.property.toString().toLowerCase();
 
-            if (propertiesToCheck[name]){
+            if (propertiesToCheck[name]) {
                 properties[name] = 1;
             }
         });
@@ -8995,19 +9825,20 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "star-property-hack",
     name: "Disallow properties with a star prefix",
     desc: "Checks for the star property hack (targets IE6/7)",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-star-hack",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this;
 
-        //check if property name starts with "*"
-        parser.addListener("property", function(event){
+        // check if property name starts with "*"
+        parser.addListener("property", function(event) {
             var property = event.property;
 
             if (property.hack === "*") {
@@ -9024,28 +9855,29 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "text-indent",
     name: "Disallow negative text-indent",
     desc: "Checks for text indent less than -99px",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-negative-text-indent",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             textIndent,
             direction;
 
 
-        function startRule(){
+        function startRule() {
             textIndent = false;
             direction = "inherit";
         }
 
-        //event handler for end of rules
-        function endRule(){
-            if (textIndent && direction !== "ltr"){
+        // event handler for end of rules
+        function endRule() {
+            if (textIndent && direction !== "ltr") {
                 reporter.report("Negative text-indent doesn't work well with RTL. If you use text-indent for image replacement explicitly set direction for that item to ltr.", textIndent.line, textIndent.col, rule);
             }
         }
@@ -9053,14 +9885,14 @@ CSSLint.addRule({
         parser.addListener("startrule", startRule);
         parser.addListener("startfontface", startRule);
 
-        //check for use of "font-size"
-        parser.addListener("property", function(event){
+        // check for use of "font-size"
+        parser.addListener("property", function(event) {
             var name = event.property.toString().toLowerCase(),
                 value = event.value;
 
-            if (name === "text-indent" && value.parts[0].value < -99){
+            if (name === "text-indent" && value.parts[0].value < -99) {
                 textIndent = event.property;
-            } else if (name === "direction" && value.toString() === "ltr"){
+            } else if (name === "direction" && value.toString() === "ltr") {
                 direction = "ltr";
             }
         });
@@ -9079,19 +9911,20 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "underscore-property-hack",
     name: "Disallow properties with an underscore prefix",
     desc: "Checks for the underscore property hack (targets IE6)",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-underscore-hack",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this;
 
-        //check if property name starts with "_"
-        parser.addListener("property", function(event){
+        // check if property name starts with "_"
+        parser.addListener("property", function(event) {
             var property = event.property;
 
             if (property.hack === "_") {
@@ -9107,47 +9940,48 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "unique-headings",
     name: "Headings should only be defined once",
     desc: "Headings should be defined only once.",
+    url: "https://github.com/CSSLint/csslint/wiki/Headings-should-only-be-defined-once",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this;
 
         var headings = {
-                h1: 0,
-                h2: 0,
-                h3: 0,
-                h4: 0,
-                h5: 0,
-                h6: 0
-            };
+            h1: 0,
+            h2: 0,
+            h3: 0,
+            h4: 0,
+            h5: 0,
+            h6: 0
+        };
 
-        parser.addListener("startrule", function(event){
+        parser.addListener("startrule", function(event) {
             var selectors = event.selectors,
                 selector,
                 part,
                 pseudo,
                 i, j;
 
-            for (i=0; i < selectors.length; i++){
+            for (i=0; i < selectors.length; i++) {
                 selector = selectors[i];
                 part = selector.parts[selector.parts.length-1];
 
-                if (part.elementName && /(h[1-6])/i.test(part.elementName.toString())){
+                if (part.elementName && /(h[1-6])/i.test(part.elementName.toString())) {
 
-                    for (j=0; j < part.modifiers.length; j++){
-                        if (part.modifiers[j].type === "pseudo"){
+                    for (j=0; j < part.modifiers.length; j++) {
+                        if (part.modifiers[j].type === "pseudo") {
                             pseudo = true;
                             break;
                         }
                     }
 
-                    if (!pseudo){
+                    if (!pseudo) {
                         headings[RegExp.$1]++;
                         if (headings[RegExp.$1] > 1) {
                             reporter.report("Heading (" + part.elementName + ") has already been defined.", part.line, part.col, rule);
@@ -9157,19 +9991,19 @@ CSSLint.addRule({
             }
         });
 
-        parser.addListener("endstylesheet", function(){
+        parser.addListener("endstylesheet", function() {
             var prop,
                 messages = [];
 
-            for (prop in headings){
-                if (headings.hasOwnProperty(prop)){
-                    if (headings[prop] > 1){
+            for (prop in headings) {
+                if (headings.hasOwnProperty(prop)) {
+                    if (headings[prop] > 1) {
                         messages.push(headings[prop] + " " + prop + "s");
                     }
                 }
             }
 
-            if (messages.length){
+            if (messages.length) {
                 reporter.rollupWarn("You have " + messages.join(", ") + " defined in this stylesheet.", rule);
             }
         });
@@ -9183,28 +10017,29 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "universal-selector",
     name: "Disallow universal selector",
     desc: "The universal selector (*) is known to be slow.",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-universal-selector",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this;
 
-        parser.addListener("startrule", function(event){
+        parser.addListener("startrule", function(event) {
             var selectors = event.selectors,
                 selector,
                 part,
                 i;
 
-            for (i=0; i < selectors.length; i++){
+            for (i=0; i < selectors.length; i++) {
                 selector = selectors[i];
 
                 part = selector.parts[selector.parts.length-1];
-                if (part.elementName === "*"){
+                if (part.elementName === "*") {
                     reporter.report(rule.desc, part.line, part.col, rule);
                 }
             }
@@ -9219,34 +10054,48 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "unqualified-attributes",
     name: "Disallow unqualified attribute selectors",
     desc: "Unqualified attribute selectors are known to be slow.",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-unqualified-attribute-selectors",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
+
         var rule = this;
 
-        parser.addListener("startrule", function(event){
+        parser.addListener("startrule", function(event) {
 
             var selectors = event.selectors,
+                selectorContainsClassOrId = false,
                 selector,
                 part,
                 modifier,
                 i, k;
 
-            for (i=0; i < selectors.length; i++){
+            for (i=0; i < selectors.length; i++) {
                 selector = selectors[i];
 
                 part = selector.parts[selector.parts.length-1];
-                if (part.type === parser.SELECTOR_PART_TYPE){
-                    for (k=0; k < part.modifiers.length; k++){
+                if (part.type === parser.SELECTOR_PART_TYPE) {
+                    for (k=0; k < part.modifiers.length; k++) {
                         modifier = part.modifiers[k];
-                        if (modifier.type === "attribute" && (!part.elementName || part.elementName === "*")){
-                            reporter.report(rule.desc, part.line, part.col, rule);
+
+                        if (modifier.type === "class" || modifier.type === "id") {
+                            selectorContainsClassOrId = true;
+                            break;
+                        }
+                    }
+
+                    if (!selectorContainsClassOrId) {
+                        for (k=0; k < part.modifiers.length; k++) {
+                            modifier = part.modifiers[k];
+                            if (modifier.type === "attribute" && (!part.elementName || part.elementName === "*")) {
+                                reporter.report(rule.desc, part.line, part.col, rule);
+                            }
                         }
                     }
                 }
@@ -9264,14 +10113,15 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "vendor-prefix",
     name: "Require standard property with vendor prefix",
     desc: "When using a vendor-prefixed property, make sure to include the standard one.",
+    url: "https://github.com/CSSLint/csslint/wiki/Require-standard-property-with-vendor-prefix",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this,
             properties,
@@ -9322,28 +10172,28 @@ CSSLint.addRule({
                 "-moz-box-shadow": "box-shadow",
                 "-webkit-box-shadow": "box-shadow",
 
-                "-moz-transform" : "transform",
-                "-webkit-transform" : "transform",
-                "-o-transform" : "transform",
-                "-ms-transform" : "transform",
+                "-moz-transform": "transform",
+                "-webkit-transform": "transform",
+                "-o-transform": "transform",
+                "-ms-transform": "transform",
 
-                "-moz-transform-origin" : "transform-origin",
-                "-webkit-transform-origin" : "transform-origin",
-                "-o-transform-origin" : "transform-origin",
-                "-ms-transform-origin" : "transform-origin",
+                "-moz-transform-origin": "transform-origin",
+                "-webkit-transform-origin": "transform-origin",
+                "-o-transform-origin": "transform-origin",
+                "-ms-transform-origin": "transform-origin",
 
-                "-moz-box-sizing" : "box-sizing",
-                "-webkit-box-sizing" : "box-sizing"
+                "-moz-box-sizing": "box-sizing",
+                "-webkit-box-sizing": "box-sizing"
             };
 
-        //event handler for beginning of rules
-        function startRule(){
+        // event handler for beginning of rules
+        function startRule() {
             properties = {};
             num = 1;
         }
 
-        //event handler for end of rules
-        function endRule(){
+        // event handler for end of rules
+        function endRule() {
             var prop,
                 i,
                 len,
@@ -9351,21 +10201,24 @@ CSSLint.addRule({
                 actual,
                 needsStandard = [];
 
-            for (prop in properties){
-                if (propertiesToCheck[prop]){
-                    needsStandard.push({ actual: prop, needed: propertiesToCheck[prop]});
+            for (prop in properties) {
+                if (propertiesToCheck[prop]) {
+                    needsStandard.push({
+                        actual: prop,
+                        needed: propertiesToCheck[prop]
+                    });
                 }
             }
 
-            for (i=0, len=needsStandard.length; i < len; i++){
+            for (i=0, len=needsStandard.length; i < len; i++) {
                 needed = needsStandard[i].needed;
                 actual = needsStandard[i].actual;
 
-                if (!properties[needed]){
+                if (!properties[needed]) {
                     reporter.report("Missing standard property '" + needed + "' to go along with '" + actual + "'.", properties[actual][0].name.line, properties[actual][0].name.col, rule);
                 } else {
-                    //make sure standard property is last
-                    if (properties[needed][0].pos < properties[actual][0].pos){
+                    // make sure standard property is last
+                    if (properties[needed][0].pos < properties[actual][0].pos) {
                         reporter.report("Standard property '" + needed + "' should come after vendor-prefixed property '" + actual + "'.", properties[actual][0].name.line, properties[actual][0].name.col, rule);
                     }
                 }
@@ -9380,14 +10233,18 @@ CSSLint.addRule({
         parser.addListener("startkeyframerule", startRule);
         parser.addListener("startviewport", startRule);
 
-        parser.addListener("property", function(event){
+        parser.addListener("property", function(event) {
             var name = event.property.text.toLowerCase();
 
-            if (!properties[name]){
+            if (!properties[name]) {
                 properties[name] = [];
             }
 
-            properties[name].push({ name: event.property, value : event.value, pos:num++ });
+            properties[name].push({
+                name: event.property,
+                value: event.value,
+                pos: num++
+            });
         });
 
         parser.addListener("endrule", endRule);
@@ -9406,25 +10263,26 @@ CSSLint.addRule({
 
 CSSLint.addRule({
 
-    //rule information
+    // rule information
     id: "zero-units",
     name: "Disallow units for 0 values",
     desc: "You don't need to specify units when a value is 0.",
+    url: "https://github.com/CSSLint/csslint/wiki/Disallow-units-for-zero-values",
     browsers: "All",
 
-    //initialization
-    init: function(parser, reporter){
+    // initialization
+    init: function(parser, reporter) {
         "use strict";
         var rule = this;
 
-        //count how many times "float" is used
-        parser.addListener("property", function(event){
+        // count how many times "float" is used
+        parser.addListener("property", function(event) {
             var parts = event.value.parts,
                 i = 0,
                 len = parts.length;
 
-            while(i < len){
-                if ((parts[i].units || parts[i].type === "percentage") && parts[i].value === 0 && parts[i].type !== "time"){
+            while (i < len) {
+                if ((parts[i].units || parts[i].type === "percentage") && parts[i].value === 0 && parts[i].type !== "time") {
                     reporter.report("Values of 0 shouldn't have units specified.", parts[i].line, parts[i].col, rule);
                 }
                 i++;
@@ -9456,7 +10314,7 @@ CSSLint.addRule({
             return "";
         }
 
-        return str.replace(/[\"&><]/g, function(match) {
+        return str.replace(/["&><]/g, function(match) {
             switch (match) {
                 case "\"":
                     return "&quot;";
@@ -9471,7 +10329,7 @@ CSSLint.addRule({
     };
 
     CSSLint.addFormatter({
-        //format information
+        // format information
         id: "checkstyle-xml",
         name: "Checkstyle XML format",
 
@@ -9479,7 +10337,7 @@ CSSLint.addRule({
          * Return opening root XML tag.
          * @return {String} to prepend before all results
          */
-        startFormat: function(){
+        startFormat: function() {
             return "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle>";
         },
 
@@ -9487,7 +10345,7 @@ CSSLint.addRule({
          * Return closing root XML tag.
          * @return {String} to append after all results
          */
-        endFormat: function(){
+        endFormat: function() {
             return "</checkstyle>";
         },
 
@@ -9523,15 +10381,14 @@ CSSLint.addRule({
                 if (!rule || !("name" in rule)) {
                     return "";
                 }
-                return "net.csslint." + rule.name.replace(/\s/g,"");
+                return "net.csslint." + rule.name.replace(/\s/g, "");
             };
-
 
 
             if (messages.length > 0) {
                 output.push("<file name=\""+filename+"\">");
                 CSSLint.Util.forEach(messages, function (message) {
-                    //ignore rollups for now
+                    // ignore rollups for now
                     if (!message.rollup) {
                         output.push("<error line=\"" + message.line + "\" column=\"" + message.col + "\" severity=\"" + message.type + "\"" +
                           " message=\"" + xmlEscape(message.message) + "\" source=\"" + generateSource(message.rule) +"\"/>");
@@ -9547,7 +10404,7 @@ CSSLint.addRule({
 }());
 
 CSSLint.addFormatter({
-    //format information
+    // format information
     id: "compact",
     name: "Compact, 'porcelain' format",
 
@@ -9592,14 +10449,14 @@ CSSLint.addFormatter({
         };
 
         if (messages.length === 0) {
-              return options.quiet ? "" : filename + ": Lint Free!";
+            return options.quiet ? "" : filename + ": Lint Free!";
         }
 
         CSSLint.Util.forEach(messages, function(message) {
             if (message.rollup) {
-                output += filename + ": " + capitalize(message.type) + " - " + message.message + "\n";
+                output += filename + ": " + capitalize(message.type) + " - " + message.message + " (" + message.rule.id + ")\n";
             } else {
-                output += filename + ": " + "line " + message.line +
+                output += filename + ": line " + message.line +
                     ", col " + message.col + ", " + capitalize(message.type) + " - " + message.message + " (" + message.rule.id + ")\n";
             }
         });
@@ -9609,7 +10466,7 @@ CSSLint.addFormatter({
 });
 
 CSSLint.addFormatter({
-    //format information
+    // format information
     id: "csslint-xml",
     name: "CSSLint XML format",
 
@@ -9617,7 +10474,7 @@ CSSLint.addFormatter({
      * Return opening root XML tag.
      * @return {String} to prepend before all results
      */
-    startFormat: function(){
+    startFormat: function() {
         "use strict";
         return "<?xml version=\"1.0\" encoding=\"utf-8\"?><csslint>";
     },
@@ -9626,7 +10483,7 @@ CSSLint.addFormatter({
      * Return closing root XML tag.
      * @return {String} to append after all results
      */
-    endFormat: function(){
+    endFormat: function() {
         "use strict";
         return "</csslint>";
     },
@@ -9659,7 +10516,7 @@ CSSLint.addFormatter({
             if (!str || str.constructor !== String) {
                 return "";
             }
-            return str.replace(/\"/g, "'").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+            return str.replace(/"/g, "'").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
         };
 
         if (messages.length > 0) {
@@ -9679,8 +10536,61 @@ CSSLint.addFormatter({
     }
 });
 
+/* globals JSON: true */
+
 CSSLint.addFormatter({
-    //format information
+    // format information
+    id: "json",
+    name: "JSON",
+
+    /**
+     * Return content to be printed before all file results.
+     * @return {String} to prepend before all results
+     */
+    startFormat: function() {
+        "use strict";
+        this.json = [];
+        return "";
+    },
+
+    /**
+     * Return content to be printed after all file results.
+     * @return {String} to append after all results
+     */
+    endFormat: function() {
+        "use strict";
+        var ret = "";
+        if (this.json.length > 0) {
+            if (this.json.length === 1) {
+                ret = JSON.stringify(this.json[0]);
+            } else {
+                ret = JSON.stringify(this.json);
+            }
+        }
+        return ret;
+    },
+
+    /**
+     * Given CSS Lint results for a file, return output for this format.
+     * @param results {Object} with error and warning messages
+     * @param filename {String} relative file path (Unused)
+     * @return {String} output for results
+     */
+    formatResults: function(results, filename, options) {
+        "use strict";
+        if (results.messages.length > 0 || !options.quiet) {
+            this.json.push({
+                filename: filename,
+                messages: results.messages,
+                stats: results.stats
+            });
+        }
+        return "";
+    }
+});
+
+CSSLint.addFormatter({
+    // format information
     id: "junit-xml",
     name: "JUNIT XML format",
 
@@ -9688,7 +10598,7 @@ CSSLint.addFormatter({
      * Return opening root XML tag.
      * @return {String} to prepend before all results
      */
-    startFormat: function(){
+    startFormat: function() {
         "use strict";
         return "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites>";
     },
@@ -9730,7 +10640,7 @@ CSSLint.addFormatter({
             if (!rule || !("name" in rule)) {
                 return "";
             }
-            return "net.csslint." + rule.name.replace(/\s/g,"");
+            return "net.csslint." + rule.name.replace(/\s/g, "");
         };
 
         /**
@@ -9750,7 +10660,7 @@ CSSLint.addFormatter({
                 return "";
             }
 
-            return str.replace(/\"/g, "'").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+            return str.replace(/"/g, "'").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
         };
 
@@ -9762,13 +10672,13 @@ CSSLint.addFormatter({
                 // all issues as errors
                 var type = message.type === "warning" ? "error" : message.type;
 
-                //ignore rollups for now
+                // ignore rollups for now
                 if (!message.rollup) {
 
-                    // build the test case seperately, once joined
+                    // build the test case separately, once joined
                     // we'll add it to a custom array filtered by type
                     output.push("<testcase time=\"0\" name=\"" + generateSource(message.rule) + "\">");
-                    output.push("<" + type + " message=\"" + escapeSpecialCharacters(message.message) + "\"><![CDATA[" + message.line + ":" + message.col + ":" + escapeSpecialCharacters(message.evidence)  + "]]></" + type + ">");
+                    output.push("<" + type + " message=\"" + escapeSpecialCharacters(message.message) + "\"><![CDATA[" + message.line + ":" + message.col + ":" + escapeSpecialCharacters(message.evidence) + "]]></" + type + ">");
                     output.push("</testcase>");
 
                     tests[type] += 1;
@@ -9788,7 +10698,7 @@ CSSLint.addFormatter({
 });
 
 CSSLint.addFormatter({
-    //format information
+    // format information
     id: "lint-xml",
     name: "Lint XML format",
 
@@ -9796,7 +10706,7 @@ CSSLint.addFormatter({
      * Return opening root XML tag.
      * @return {String} to prepend before all results
      */
-    startFormat: function(){
+    startFormat: function() {
         "use strict";
         return "<?xml version=\"1.0\" encoding=\"utf-8\"?><lint>";
     },
@@ -9805,7 +10715,7 @@ CSSLint.addFormatter({
      * Return closing root XML tag.
      * @return {String} to append after all results
      */
-    endFormat: function(){
+    endFormat: function() {
         "use strict";
         return "</lint>";
     },
@@ -9838,7 +10748,7 @@ CSSLint.addFormatter({
             if (!str || str.constructor !== String) {
                 return "";
             }
-            return str.replace(/\"/g, "'").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+            return str.replace(/"/g, "'").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
         };
 
         if (messages.length > 0) {
@@ -9848,7 +10758,11 @@ CSSLint.addFormatter({
                 if (message.rollup) {
                     output.push("<issue severity=\"" + message.type + "\" reason=\"" + escapeSpecialCharacters(message.message) + "\" evidence=\"" + escapeSpecialCharacters(message.evidence) + "\"/>");
                 } else {
-                    output.push("<issue line=\"" + message.line + "\" char=\"" + message.col + "\" severity=\"" + message.type + "\"" +
+                    var rule = "";
+                    if (message.rule && message.rule.id) {
+                        rule = "rule=\"" + escapeSpecialCharacters(message.rule.id) + "\" ";
+                    }
+                    output.push("<issue " + rule + "line=\"" + message.line + "\" char=\"" + message.col + "\" severity=\"" + message.type + "\"" +
                         " reason=\"" + escapeSpecialCharacters(message.message) + "\" evidence=\"" + escapeSpecialCharacters(message.evidence) + "\"/>");
                 }
             });
@@ -9860,7 +10774,7 @@ CSSLint.addFormatter({
 });
 
 CSSLint.addFormatter({
-    //format information
+    // format information
     id: "text",
     name: "Plain Text",
 
@@ -9903,17 +10817,17 @@ CSSLint.addFormatter({
         if (messages.length === 1) {
             output += "is 1 problem";
         } else {
-            output += "are " + messages.length  +  " problems";
+            output += "are " + messages.length + " problems";
         }
         output += " in " + filename + ".";
 
         var pos = filename.lastIndexOf("/"),
             shortFilename = filename;
 
-        if (pos === -1){
+        if (pos === -1) {
             pos = filename.lastIndexOf("\\");
         }
-        if (pos > -1){
+        if (pos > -1) {
             shortFilename = filename.substring(pos+1);
         }
 


### PR DESCRIPTION
Current csslint version is ancient and doesn't recognise many new properties such as `all` introduced in the CSS4 spec with widespread support.

Have to forgo the extension and upload changes directly on userstyles due to this, as linting errors block saving.

![](http://i.imgur.com/GucjTqt.png)

Using npm would also be 👌 to reduce version bumps like this causing thousands of line changes.